### PR TITLE
Connect the instrumentor with the fuzzer

### DIFF
--- a/.github/workflows/run-all-tests.yaml
+++ b/.github/workflows/run-all-tests.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           cache: "npm"
       - name: Install Dependencies
         run: npm install
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           cache: "npm"
       - name: Install Dependencies
         run: npm install

--- a/packages/fuzzer/CMakeLists.txt
+++ b/packages/fuzzer/CMakeLists.txt
@@ -27,7 +27,10 @@ endif()
 # releases.)
 add_definitions(-DNAPI_VERSION=3)
 
-add_library(${PROJECT_NAME} SHARED "fuzzy-eagle.cpp" ${CMAKE_JS_SRC})
+add_library(${PROJECT_NAME} SHARED
+  "fuzzy-eagle.cpp"
+  "shared/callbacks.cpp"
+  ${CMAKE_JS_SRC})
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_JS_INC})
 target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB})

--- a/packages/fuzzer/README.md
+++ b/packages/fuzzer/README.md
@@ -1,10 +1,10 @@
-# Fuzzer plugin for Node
+# Fuzzer addon for Node
 
-This plugin loads libfuzzer into Node. Users can install it with `npm install`,
+This addon loads libfuzzer into Node. Users can install it with `npm install`,
 which tries to download a prebuilt shared object from GitHub but falls back to
 compilation on the user's machine if there is no suitable binary.
 
-Loading the plugin initializes libfuzzer and the sanitizer runtime. Users can
+Loading the addon initializes libfuzzer and the sanitizer runtime. Users can
 then start the fuzzer with the `startFuzzing` function; see [the
 test](test_fuzzer.js) for an example. For the time being, the fuzzer runs on the
 main thread and therefore blocks Node's event loop; this is most likely what
@@ -13,8 +13,10 @@ users want, so that their JS fuzz target can run in its normal environment.
 ## Development
 
 The project can be built with `npm run compile` (which is incremental after the
-first build); a subsequent `npm test` makes sure that the plugin loads cleanly.
-Binaries can be prebuilt with `npm run prebuild` and uploaded with `npm run upload`.
+first build); a subsequent `npm test` makes sure that the addon loads cleanly.
+Binaries can be prebuilt with `npm run prebuild` and uploaded with
+`npm run upload`. Please format the code with `clang-format` (or use the format
+functionality of `clangd`).
 
 Internally, the build system uses several steps:
 
@@ -29,10 +31,10 @@ Internally, the build system uses several steps:
 5. In our CMake configuration, we set up compiler-rt as an external project;
    CMake fetches and builds it before compiling our own code against it.
 
-To debug build issues, it's often useful to start with a plain `cmake-js compile` or `cmake-js recompile`, which just invokes CMake with a few extra
-arguments that help it to find the Node headers and such.
+To debug build issues, it's often useful to start with a plain
+`cmake-js compile` or `cmake-js recompile`, which just invokes CMake with a few
+extra arguments that help it to find the Node headers and such.
 
-When working on the plugin's C++ code, you may want to use a language server
-like `clangd` for IDE features. CMake is configured to emit a
-`compile_commands.json` file, so the language server should work after the first
-`npm install`.
+When working on the addon's C++ code, you may want to use a language server like
+`clangd` for IDE features. CMake is configured to emit a `compile_commands.json`
+file, so the language server should work after the first `npm install`.

--- a/packages/fuzzer/fuzzy-eagle.cpp
+++ b/packages/fuzzer/fuzzy-eagle.cpp
@@ -11,6 +11,8 @@
 #include <fuzzer/FuzzerDefs.h>
 #include <ubsan/ubsan_init.h>
 
+#include "shared/callbacks.h"
+
 namespace {
 
 // Information about a JS fuzz target.
@@ -104,6 +106,8 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
 
   exports["printVersion"] = Napi::Function::New<PrintVersion>(env);
   exports["startFuzzing"] = Napi::Function::New<StartFuzzing>(env);
+
+  RegisterCallbackExports(env, exports);
   return exports;
 }
 

--- a/packages/fuzzer/shared/README.md
+++ b/packages/fuzzer/shared/README.md
@@ -1,0 +1,32 @@
+# Shared translation code
+
+This directory contains the JS-to-C++ translation of fuzzer callbacks that is
+shared between the libfuzzer addon (for in-process fuzzing) and the native agent
+addon (for out-of-process fuzzing).
+
+## Rationale
+
+Our instrumentor component always works the same way, no matter whether it's
+used for in-process or out-of-process fuzzing. It inserts calls to JS functions
+into target code (e.g., to record string comparisons); ultimately, we want the
+calls to reach libfuzzer (in-process fuzzing) or the native agent
+(out-of-process fuzzing).
+
+While it would be the most convenient to do the JS-to-C++ translation only once,
+inside the instrumentor, and then link against one of the two addons, Node
+doesn't allow sharing of C symbols between addons. (Concretely, it loads native
+addons with `RTLD_LOCAL`.) Therefore, we include the translation layer in both
+addons, so that the instrumentor can use the JS functions corresponding to the
+fuzzer callbacks after importing either the libfuzzer addon or the native agent
+addon.
+
+## Usage
+
+Note that this directory doesn't contain a CMake project; it just provides
+library code, to be linked and used from the parent CMake projects (i.e., the
+projects for the two addons). Currently, the code lives in `packages/fuzzer`
+because the native agent addon hasn't been built yet; it can later by symlinked
+into the native agent addon and possibly moved somewhere outside either package.
+If more advanced use cases come up, we can think about adding a CMake
+configuration and exporting a static library, but for now it should be fine to
+just reference the source files from the parent projects.

--- a/packages/fuzzer/shared/callbacks.cpp
+++ b/packages/fuzzer/shared/callbacks.cpp
@@ -1,0 +1,33 @@
+#include "callbacks.h"
+
+#include <napi.h>
+
+// We expect these symbols to exist in the current plugin, provided either by
+// libfuzzer or by the native agent.
+extern "C" {
+void __sanitizer_weak_hook_strcmp(void *called_pc, const char *s1,
+                                  const char *s2, int result);
+}
+
+// Record a comparison between two strings in the target that returned unequal.
+void TraceUnequalStrings(const Napi::CallbackInfo &info) {
+  if (info.Length() != 3) {
+    throw Napi::Error::New(info.Env(),
+                           "Need three arguments: the trace ID and the two "
+                           "compared strings");
+  }
+
+  auto id = info[0].As<Napi::Number>().Int64Value();
+  auto s1 = info[1].As<Napi::String>().Utf8Value();
+  auto s2 = info[2].As<Napi::String>().Utf8Value();
+
+  // strcmp returns zero on equality, and libfuzzer doesn't care about the
+  // result beyond whether or not it's zero.
+  __sanitizer_weak_hook_strcmp((void *)id, s1.c_str(), s2.c_str(), 1);
+}
+
+void RegisterCallbackExports(Napi::Env env, Napi::Object exports) {
+  exports["traceUnequalStrings"] =
+      Napi::Function::New<TraceUnequalStrings>(env);
+  return;
+}

--- a/packages/fuzzer/shared/callbacks.h
+++ b/packages/fuzzer/shared/callbacks.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <napi.h>
+
+// Export fuzzer callbacks.
+//
+// Add all our fuzzer callback functions to the list of the module's exports;
+// these functions let JS target code provide feedback to libfuzzer or the
+// native agent.
+void RegisterCallbackExports(Napi::Env env, Napi::Object exports);

--- a/packages/fuzzer/test_fuzzer.js
+++ b/packages/fuzzer/test_fuzzer.js
@@ -6,6 +6,8 @@ fuzzer.printVersion();
 // Our fake fuzz target.
 const fuzz = (data) => {
 	console.log("Fuzz target called with", data);
+	// Fake a string comparison to make sure that libfuzzer hooks work.
+	fuzzer.traceUnequalStrings(42, "foo", "bar");
 };
 
 fuzzer.startFuzzing(fuzz, ["-runs=0"]);

--- a/packages/instrumentor/native.ts
+++ b/packages/instrumentor/native.ts
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
 
+// TODO Once the fuzzer module is converted to TS, make this a normal import. Moreover, when we add out-of-process fuzzing, we need to conditionally require either the libfuzzer module or the native agent, depending on whether we're doing in-process or out-of-process fuzzing.
+const fuzzer = require("@fuzzy-eagle/fuzzer/fuzzer"); // eslint-disable-line @typescript-eslint/no-var-requires
+
 // TODO: Pass request for next counter to native plugin
 let counter = 0;
 export function nextCounter(): number {
@@ -32,7 +35,8 @@ export function traceStrCmp(s1: string, s2: string, operator: string): boolean {
 			break;
 	}
 	if (shouldCallLibfuzzer) {
-		// TODO: Pass values to native plugin
+		// TODO Pass a proper site ID.
+		fuzzer.traceUnequalStrings(42, s1, s2);
 	}
 	return result;
 }


### PR DESCRIPTION
This commit makes the fuzzer usable from the instrumentor. Since we'll want to
add an alternative "fuzzer" implementation later (i.e., the native agent), some
code is explicitly marked as shared between implementations of the fuzzer
interface.