### PR TITLE
Add an option to perform a dry run

### DIFF
--- a/packages/core/cli.ts
+++ b/packages/core/cli.ts
@@ -99,6 +99,18 @@ yargs(process.argv.slice(2))
 					alias: "e",
 					group: "Fuzzer:",
 					default: ["node_modules"],
+				})
+				.option("dry_run", {
+					describe:
+						"Perform a dry run with the fuzzing instrumentation disabled. " +
+						"A dry run only executes the fuzz test with the inputs from the " +
+						"corpus and returns directly. That is, no fuzzing is performed. " +
+						"This option can then be used when reporting code coverage for " +
+						"a fuzz test",
+					type: "boolean",
+					alias: "d",
+					group: "Fuzzer:",
+					default: false,
 				});
 		},
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -115,6 +127,7 @@ yargs(process.argv.slice(2))
 						// empty string matches every file
 						exclude === "*" ? "" : exclude
 					),
+					dryRun: args.dry_run,
 					fuzzerOptions: args.corpus.concat(args._),
 				});
 			} catch (e: unknown) {

--- a/packages/core/core.ts
+++ b/packages/core/core.ts
@@ -22,6 +22,7 @@ interface Options {
 	fuzzFunction: string;
 	includes: string[];
 	excludes: string[];
+	dryRun: boolean;
 	fuzzerOptions: string[];
 }
 
@@ -32,7 +33,11 @@ declare global {
 
 export function startFuzzing(options: Options) {
 	globalThis.Fuzzer = fuzzer.fuzzer;
-	registerInstrumentor(options.includes, options.excludes);
+	if (options.dryRun) {
+		options.fuzzerOptions.push("-runs=0");
+	} else {
+		registerInstrumentor(options.includes, options.excludes);
+	}
 
 	// eslint-disable-next-line @typescript-eslint/no-var-requires
 	const fuzzFn = require(options.fuzzTarget)[options.fuzzFunction];


### PR DESCRIPTION
A dry run executes the fuzz test with the inputs from the corpus and
returns directly. This can be used in combination with tools such
as `nyc` to report code coverage for a fuzz test