### PR TITLE
Access fuzzer only through exported functions

### DIFF
--- a/packages/fuzzer/fuzzer.test.ts
+++ b/packages/fuzzer/fuzzer.test.ts
@@ -15,7 +15,7 @@
  */
 
 /* eslint no-empty-function: 0 */
-import { fuzzer, coverageMap } from "./fuzzer";
+import { fuzzer } from "./fuzzer";
 
 describe("compare hooks", () => {
 	it("traceStrCmp supports equals operators", () => {
@@ -28,17 +28,17 @@ describe("compare hooks", () => {
 
 describe("incrementCounter", () => {
 	it("should support the NeverZero policy", () => {
-		expect(coverageMap.readUint8(0)).toBe(0);
+		expect(fuzzer.readCounter(0)).toBe(0);
 		for (let counter = 1; counter <= 512; counter++) {
 			fuzzer.incrementCounter(0);
 			if (counter < 256) {
-				expect(coverageMap.readUint8(0)).toBe(counter);
+				expect(fuzzer.readCounter(0)).toBe(counter);
 			} else if (counter < 511) {
-				expect(coverageMap.readUint8(0)).toBe((counter % 256) + 1);
+				expect(fuzzer.readCounter(0)).toBe((counter % 256) + 1);
 			} else if (counter == 511) {
-				expect(coverageMap.readUint8(0)).toBe(1);
+				expect(fuzzer.readCounter(0)).toBe(1);
 			} else {
-				expect(coverageMap.readUint8(0)).toBe((counter % 256) + 2);
+				expect(fuzzer.readCounter(0)).toBe((counter % 256) + 2);
 			}
 		}
 	});

--- a/packages/fuzzer/fuzzer.ts
+++ b/packages/fuzzer/fuzzer.ts
@@ -20,7 +20,7 @@ const addon = bind("jazzerjs");
 
 const MAX_NUM_COUNTERS: number = 1 << 20;
 const INITIAL_NUM_COUNTERS: number = 1 << 9;
-export const coverageMap = Buffer.alloc(MAX_NUM_COUNTERS, 0);
+const coverageMap = Buffer.alloc(MAX_NUM_COUNTERS, 0);
 
 addon.registerCoverageMap(coverageMap);
 addon.registerNewCounters(0, INITIAL_NUM_COUNTERS);
@@ -28,7 +28,7 @@ addon.registerNewCounters(0, INITIAL_NUM_COUNTERS);
 let currentNumCounters = INITIAL_NUM_COUNTERS;
 let currentCounter = 0;
 
-export function nextCounter(): number {
+function nextCounter(): number {
 	currentCounter++;
 
 	// Enlarge registered counters if needed
@@ -51,12 +51,16 @@ export function nextCounter(): number {
 	return currentCounter;
 }
 
-export function incrementCounter(id: number) {
+function incrementCounter(id: number) {
 	const counter = coverageMap.readUint8(id);
 	coverageMap.writeUint8(counter == 255 ? 1 : counter + 1, id);
 }
 
-export function traceStrCmp(
+function readCounter(id: number): number {
+	return coverageMap.readUint8(id);
+}
+
+function traceStrCmp(
 	s1: string,
 	s2: string,
 	operator: string,
@@ -88,7 +92,7 @@ export function traceStrCmp(
 	return result;
 }
 
-export function traceNumberCmp(
+function traceNumberCmp(
 	n1: number,
 	n2: number,
 	operator: string,
@@ -128,6 +132,7 @@ export interface Fuzzer {
 	startFuzzing: (fuzzFn: FuzzFn, fuzzOpts: FuzzOpts) => void;
 	nextCounter: typeof nextCounter;
 	incrementCounter: typeof incrementCounter;
+	readCounter: typeof readCounter;
 	traceStrCmp: typeof traceStrCmp;
 	traceNumberCmp: typeof traceNumberCmp;
 }
@@ -140,6 +145,7 @@ export const fuzzer: Fuzzer = {
 	) => void,
 	nextCounter,
 	incrementCounter,
+	readCounter,
 	traceStrCmp,
 	traceNumberCmp,
 };

--- a/packages/instrumentor/plugins/codeCoverage.test.ts
+++ b/packages/instrumentor/plugins/codeCoverage.test.ts
@@ -18,7 +18,7 @@ import { codeCoverage } from "./codeCoverage";
 import { instrumentWith } from "./testhelpers";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const native = require("@jazzer.js/fuzzer");
+const native = require("@jazzer.js/fuzzer").fuzzer;
 jest.mock("@jazzer.js/fuzzer");
 native.nextCounter.mockReturnValue(0);
 

--- a/packages/instrumentor/plugins/codeCoverage.ts
+++ b/packages/instrumentor/plugins/codeCoverage.ts
@@ -28,7 +28,7 @@ import {
 	TryStatement,
 } from "@babel/types";
 import { NodePath, PluginTarget, types } from "@babel/core";
-import { nextCounter } from "@jazzer.js/fuzzer";
+import { fuzzer } from "@jazzer.js/fuzzer";
 
 export function codeCoverage(): PluginTarget {
 	return {
@@ -114,6 +114,6 @@ function makeCounterIncStmt(): ExpressionStatement {
 
 function makeCounterIncExpr(): Expression {
 	return types.callExpression(types.identifier("Fuzzer.incrementCounter"), [
-		types.numericLiteral(nextCounter()),
+		types.numericLiteral(fuzzer.nextCounter()),
 	]);
 }

--- a/packages/instrumentor/plugins/compareHooks.test.ts
+++ b/packages/instrumentor/plugins/compareHooks.test.ts
@@ -156,7 +156,7 @@ describe("compare hooks instrumentation", () => {
 // API function with a jest mock, which can be configured in the test.
 function mockNativeAddonApi() {
 	// eslint-disable-next-line @typescript-eslint/no-var-requires
-	const native = require("@jazzer.js/fuzzer");
+	const native = require("@jazzer.js/fuzzer").fuzzer;
 	jest.mock("@jazzer.js/fuzzer");
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore


### PR DESCRIPTION
The fuzzer module should only export types and the fuzzer object, no
internal state. Not exporting the compare functions and coverageMap
hides the internal structure better.