### PR TITLE
Add dependabot automerge action

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,0 +1,18 @@
+name: automerge
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v3.0.0
+        with:
+          target: minor
+          merge-method: rebase
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Manually approving and merging all dependabot PRs is a hassle. This PR adds an action to do so automatically.