### PR TITLE
Restrict npm build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	},
 	"scripts": {
 		"prepare": "husky install",
-		"build": "tsc -b tsconfig.build.json && npm run build --ws --if-present",
+		"build": "tsc -b tsconfig.build.json",
 		"compile:watch": "tsc -p . --incremental --pretty --watch",
 		"test": "jest && npm run test --ws --if-present && cd examples && bash dry_run.sh",
 		"test:watch": "jest --watch",


### PR DESCRIPTION
`npm run build` should not trigger a rebuild of the native components. This
takes a long time, especially in the CI.