### PR TITLE
Fix GCC 12 build errors

### DIFF
--- a/packages/fuzzer/.gitignore
+++ b/packages/fuzzer/.gitignore
@@ -1,2 +1,3 @@
 build
 prebuilds
+cmake-build-debug

--- a/packages/fuzzer/start_fuzzing_sync.cpp
+++ b/packages/fuzzer/start_fuzzing_sync.cpp
@@ -14,6 +14,7 @@
 
 #include "start_fuzzing_sync.h"
 #include "utils.h"
+#include <optional>
 
 namespace {
 // Information about a JS fuzz target.


### PR DESCRIPTION
GCC 12 raises a build error due to a missing include of optional.
Also ignore the cmake build directory.