### PR TITLE
Detect timeouts in async fuzzing mode

### DIFF
--- a/.github/workflows/run-all-tests.yaml
+++ b/.github/workflows/run-all-tests.yaml
@@ -23,6 +23,8 @@ jobs:
         run: npm install
       - name: install dependencies with apt
         run: sudo apt-get install --yes clang-tidy
+      - name: build fuzzer
+        run: npm run build -w=@jazzer.js/fuzzer
       - name: check formatting and linting
         run: npm run check
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Fuzzer reports
 crash-*
 oom-*
+timeout-*
 
 # Editors
 .idea

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,11 @@
 # Docs
 
+## User Guides
+
+- [Advanced Fuzzing Settings](fuzz-settings.md)
+
+## Internal Documentation
+
 - [Development](development.md)
 - [Release](release.md)
 - [Architecture](architecture.md)

--- a/docs/fuzz-settings.md
+++ b/docs/fuzz-settings.md
@@ -1,0 +1,34 @@
+# Advanced Fuzzing Settings
+
+This page describes advanced fuzzing settings.
+
+## Timeout
+
+Invocations of fuzz targets, which take longer than the configured timeout, will
+cause fuzzing to stop and a timeout finding to be reported. This feature is
+directly provided by the underlying fuzzing engine, libFuzzer.
+
+A [default timeout](https://www.llvm.org/docs/LibFuzzer.html#output) of 1200
+seconds is preconfigured, but can be changed using the `-timeout` fuzzer flag.
+
+Timeouts work in the sync- and asynchronous fuzzing mode.
+
+Example invocation:
+
+```shell
+npx jazzer fuzzTarget -- -timeout=10
+```
+
+Example output:
+
+```text
+ALARM: working on the last Unit for 10 seconds
+       and the timeout value is 10 (use -timeout=N to change)
+MS: 2 ShuffleBytes-InsertRepeatedBytes-; base unit: adc83b19e793491b1c6ea0fd8b46cd9f32e592fc
+0xe3,0xe3,0xe3,0xe3,0xe3,0xe3,0xe3,0xe3,0xe3,0xe3,0xa,
+\343\343\343\343\343\343\343\343\343\343\012
+artifact_prefix='./'; Test unit written to ./timeout-d593b924e138abd8ec4c97afe40c408136ecabd4
+Base64: 4+Pj4+Pj4+Pj4wo=
+==96284== ERROR: libFuzzer: timeout after 10 seconds
+SUMMARY: libFuzzer: timeout
+```

--- a/examples/timeout/fuzz.js
+++ b/examples/timeout/fuzz.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @param { Buffer } data
+ */
+module.exports.fuzz = function (data) {
+	return new Promise((resolve) => {
+		if (data.length <= 10) {
+			resolve();
+		}
+		// else never resolve the promise
+	});
+};

--- a/examples/timeout/package-lock.json
+++ b/examples/timeout/package-lock.json
@@ -1,0 +1,72 @@
+{
+	"name": "jazzerjs-timeout-example",
+	"version": "1.0.0",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "jazzerjs-timeout-example",
+			"version": "1.0.0",
+			"devDependencies": {
+				"@jazzer.js/core": "file:../../packages/core"
+			}
+		},
+		"../../packages/core": {
+			"name": "@jazzer.js/core",
+			"version": "1.0.1",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jazzer.js/instrumentor": "*",
+				"yargs": "^17.5.1"
+			},
+			"bin": {
+				"jazzer": "dist/cli.js"
+			},
+			"devDependencies": {
+				"@types/yargs": "^17.0.11"
+			},
+			"engines": {
+				"node": ">= 14.0.0",
+				"npm": ">= 7.0.0"
+			}
+		},
+		"../../packages/fuzzer": {
+			"name": "@jazzer.js/fuzzer",
+			"version": "1.0.1",
+			"extraneous": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bindings": "^1.5.0",
+				"cmake-js": "^6.3.2",
+				"node-addon-api": "^5.0.0",
+				"prebuild-install": "^7.1.1"
+			},
+			"devDependencies": {
+				"@types/bindings": "^1.5.1",
+				"@types/node": "^18.7.12",
+				"clang-format": "^1.8.0",
+				"prebuild": "^11.0.4"
+			},
+			"engines": {
+				"node": ">= 14.0.0",
+				"npm": ">= 7.0.0"
+			}
+		},
+		"node_modules/@jazzer.js/core": {
+			"resolved": "../../packages/core",
+			"link": true
+		}
+	},
+	"dependencies": {
+		"@jazzer.js/core": {
+			"version": "file:../../packages/core",
+			"requires": {
+				"@jazzer.js/instrumentor": "*",
+				"@types/yargs": "^17.0.11",
+				"yargs": "^17.5.1"
+			}
+		}
+	}
+}

--- a/examples/timeout/package.json
+++ b/examples/timeout/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "jazzerjs-timeout-example",
+	"version": "1.0.0",
+	"description": "An example showing how Jazzer.js handles timeouts",
+	"scripts": {
+		"fuzz": "jazzer fuzz -- -timeout=1",
+		"dryRun": "echo \"skipped\""
+	},
+	"devDependencies": {
+		"@jazzer.js/core": "file:../../packages/core"
+	}
+}

--- a/packages/fuzzer/CMakeLists.txt
+++ b/packages/fuzzer/CMakeLists.txt
@@ -77,7 +77,8 @@ ExternalProject_Add(compiler-rt
   PATCH_COMMAND
     ${Patch_EXECUTABLE} -p1 < ${CMAKE_CURRENT_LIST_DIR}/patches/transform_exit_to_return.patch &&
     ${Patch_EXECUTABLE} -p1 < ${CMAKE_CURRENT_LIST_DIR}/patches/add_with_pc_sanitizer_cov_tracing_functions.patch &&
-    ${Patch_EXECUTABLE} -p1 < ${CMAKE_CURRENT_LIST_DIR}/patches/fix_cmake_windows.patch
+    ${Patch_EXECUTABLE} -p1 < ${CMAKE_CURRENT_LIST_DIR}/patches/fix_cmake_windows.patch &&
+    ${Patch_EXECUTABLE} -p1 < ${CMAKE_CURRENT_LIST_DIR}/patches/sigalrm_handler.patch
   CMAKE_ARGS
   # compiler-rt usually initializes the sanitizer runtime by means of a pointer
   # in the .preinit_array section; since .preinit_array isn't supported for

--- a/packages/fuzzer/patches/sigalrm_handler.patch
+++ b/packages/fuzzer/patches/sigalrm_handler.patch
@@ -1,0 +1,17 @@
+--- a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
+@@ -276,9 +276,11 @@ void Fuzzer::AlarmCallback() {
+   assert(Options.UnitTimeoutSec > 0);
+   // In Windows and Fuchsia, Alarm callback is executed by a different thread.
+   // NetBSD's current behavior needs this change too.
+-#if !LIBFUZZER_WINDOWS && !LIBFUZZER_NETBSD && !LIBFUZZER_FUCHSIA
+-  if (!InFuzzingThread())
+-    return;
++#if !LIBFUZZER_WINDOWS && !LIBFUZZER_NETBSD && !LIBFUZZER_FUCHSIA
++// Signals are received by the first thread, which normally is libFuzzer's
++// "myThread". When executed in a separate thread, as in the async fuzzing
++// case of Jazzer.js, this is not the case anymore and the patched out
++// thread name check prevents proper signal handling.
+ #endif
+   if (!RunningUserCallback)
+     return; // We have not started running units yet.

--- a/packages/fuzzer/start_fuzzing_async.cpp
+++ b/packages/fuzzer/start_fuzzing_async.cpp
@@ -173,6 +173,8 @@ Napi::Value StartFuzzingAsync(const Napi::CallbackInfo &info) {
         delete ctx;
       });
 
+  // Start the libFuzzer loop in a separate thread in order not to block the
+  // JavaScript event loop
   context->native_thread = std::thread(
       [](std::vector<std::string> fuzzer_args, AsyncFuzzTargetContext *ctx) {
         StartLibFuzzer(fuzzer_args, FuzzCallbackAsync);

--- a/packages/fuzzer/utils.cpp
+++ b/packages/fuzzer/utils.cpp
@@ -29,8 +29,6 @@ void StartLibFuzzer(const std::vector<std::string> &args,
   int argc = fuzzer_arg_pointers.size();
   char **argv = fuzzer_arg_pointers.data();
 
-  // Start the libFuzzer loop in a separate thread in order not to block
-  // JavaScript event loop
   fuzzer::FuzzerDriver(&argc, &argv, fuzzCallback);
 }
 


### PR DESCRIPTION
Timeouts can be directly configured by the libFuzzer flag -timeout. In
case of async fuzzing, this was not handled correctly.

When receiving a sigalrm signal, indicating a timeout, libFuzzer checks
if the signal is handled on it's thread and not another one of the
process. In case of async fuzzing libFuzzer is started in a dedicated
thread, but the signal is received by the main one, so the check fails
and no timeout finding is produced.

In this commit we patch out the mentioned check. It's already
deactivated for some platforms and doesn't seem to cause issues.