### PR TITLE
Mark fuzz tests without seed files as skipped

### DIFF
--- a/examples/FuzzedDataProvider/package-lock.json
+++ b/examples/FuzzedDataProvider/package-lock.json
@@ -25,7 +25,7 @@
 				"jazzer": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@types/yargs": "^17.0.13"
+				"@types/yargs": "^17.0.14"
 			},
 			"engines": {
 				"node": ">= 14.0.0",
@@ -43,7 +43,7 @@
 			"requires": {
 				"@jazzer.js/hooking": "*",
 				"@jazzer.js/instrumentor": "*",
-				"@types/yargs": "^17.0.13",
+				"@types/yargs": "^17.0.14",
 				"yargs": "^17.6.2"
 			}
 		}

--- a/examples/custom-hooks/package-lock.json
+++ b/examples/custom-hooks/package-lock.json
@@ -29,7 +29,7 @@
 				"jazzer": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@types/yargs": "^17.0.13"
+				"@types/yargs": "^17.0.14"
 			},
 			"engines": {
 				"node": ">= 14.0.0",
@@ -52,7 +52,7 @@
 			"requires": {
 				"@jazzer.js/hooking": "*",
 				"@jazzer.js/instrumentor": "*",
-				"@types/yargs": "^17.0.13",
+				"@types/yargs": "^17.0.14",
 				"yargs": "^17.6.2"
 			}
 		},

--- a/examples/jpeg/package-lock.json
+++ b/examples/jpeg/package-lock.json
@@ -29,7 +29,7 @@
 				"jazzer": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@types/yargs": "^17.0.13"
+				"@types/yargs": "^17.0.14"
 			},
 			"engines": {
 				"node": ">= 14.0.0",
@@ -52,7 +52,7 @@
 			"requires": {
 				"@jazzer.js/hooking": "*",
 				"@jazzer.js/instrumentor": "*",
-				"@types/yargs": "^17.0.13",
+				"@types/yargs": "^17.0.14",
 				"yargs": "^17.6.2"
 			}
 		},

--- a/examples/js-yaml/package-lock.json
+++ b/examples/js-yaml/package-lock.json
@@ -30,7 +30,7 @@
 				"jazzer": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@types/yargs": "^17.0.13"
+				"@types/yargs": "^17.0.14"
 			},
 			"engines": {
 				"node": ">= 14.0.0",
@@ -1765,7 +1765,7 @@
 			"requires": {
 				"@jazzer.js/hooking": "*",
 				"@jazzer.js/instrumentor": "*",
-				"@types/yargs": "^17.0.13",
+				"@types/yargs": "^17.0.14",
 				"yargs": "^17.6.2"
 			},
 			"dependencies": {

--- a/examples/maze/package-lock.json
+++ b/examples/maze/package-lock.json
@@ -25,7 +25,7 @@
 				"jazzer": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@types/yargs": "^17.0.13"
+				"@types/yargs": "^17.0.14"
 			},
 			"engines": {
 				"node": ">= 14.0.0",
@@ -66,7 +66,7 @@
 			"requires": {
 				"@jazzer.js/hooking": "*",
 				"@jazzer.js/instrumentor": "*",
-				"@types/yargs": "^17.0.13",
+				"@types/yargs": "^17.0.14",
 				"yargs": "^17.6.2"
 			}
 		}

--- a/examples/promise/package-lock.json
+++ b/examples/promise/package-lock.json
@@ -25,7 +25,7 @@
 				"jazzer": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@types/yargs": "^17.0.13"
+				"@types/yargs": "^17.0.14"
 			},
 			"engines": {
 				"node": ">= 14.0.0",
@@ -43,7 +43,7 @@
 			"requires": {
 				"@jazzer.js/hooking": "*",
 				"@jazzer.js/instrumentor": "*",
-				"@types/yargs": "^17.0.13",
+				"@types/yargs": "^17.0.14",
 				"yargs": "^17.6.2"
 			}
 		}

--- a/examples/spectral/package-lock.json
+++ b/examples/spectral/package-lock.json
@@ -48,7 +48,7 @@
 				"jazzer": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@types/yargs": "^17.0.13"
+				"@types/yargs": "^17.0.14"
 			},
 			"engines": {
 				"node": ">= 14.0.0",
@@ -167,7 +167,7 @@
 			"requires": {
 				"@jazzer.js/hooking": "*",
 				"@jazzer.js/instrumentor": "*",
-				"@types/yargs": "^17.0.13",
+				"@types/yargs": "^17.0.14",
 				"yargs": "^17.6.2"
 			}
 		},

--- a/examples/string_compare/package-lock.json
+++ b/examples/string_compare/package-lock.json
@@ -25,7 +25,7 @@
 				"jazzer": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@types/yargs": "^17.0.13"
+				"@types/yargs": "^17.0.14"
 			},
 			"engines": {
 				"node": ">= 14.0.0",
@@ -43,7 +43,7 @@
 			"requires": {
 				"@jazzer.js/hooking": "*",
 				"@jazzer.js/instrumentor": "*",
-				"@types/yargs": "^17.0.13",
+				"@types/yargs": "^17.0.14",
 				"yargs": "^17.6.2"
 			}
 		}

--- a/examples/switch/package-lock.json
+++ b/examples/switch/package-lock.json
@@ -25,7 +25,7 @@
 				"jazzer": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@types/yargs": "^17.0.13"
+				"@types/yargs": "^17.0.14"
 			},
 			"engines": {
 				"node": ">= 14.0.0",
@@ -43,7 +43,7 @@
 			"requires": {
 				"@jazzer.js/hooking": "*",
 				"@jazzer.js/instrumentor": "*",
-				"@types/yargs": "^17.0.13",
+				"@types/yargs": "^17.0.14",
 				"yargs": "^17.6.2"
 			}
 		}

--- a/examples/timeout/package-lock.json
+++ b/examples/timeout/package-lock.json
@@ -25,7 +25,7 @@
 				"jazzer": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@types/yargs": "^17.0.13"
+				"@types/yargs": "^17.0.14"
 			},
 			"engines": {
 				"node": ">= 14.0.0",
@@ -66,7 +66,7 @@
 			"requires": {
 				"@jazzer.js/hooking": "*",
 				"@jazzer.js/instrumentor": "*",
-				"@types/yargs": "^17.0.13",
+				"@types/yargs": "^17.0.14",
 				"yargs": "^17.6.2"
 			}
 		}

--- a/examples/value_profiling/package-lock.json
+++ b/examples/value_profiling/package-lock.json
@@ -25,7 +25,7 @@
 				"jazzer": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@types/yargs": "^17.0.13"
+				"@types/yargs": "^17.0.14"
 			},
 			"engines": {
 				"node": ">= 14.0.0",
@@ -43,7 +43,7 @@
 			"requires": {
 				"@jazzer.js/hooking": "*",
 				"@jazzer.js/instrumentor": "*",
-				"@types/yargs": "^17.0.13",
+				"@types/yargs": "^17.0.14",
 				"yargs": "^17.6.2"
 			}
 		}

--- a/examples/xml/package-lock.json
+++ b/examples/xml/package-lock.json
@@ -29,7 +29,7 @@
 				"jazzer": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@types/yargs": "^17.0.13"
+				"@types/yargs": "^17.0.14"
 			},
 			"engines": {
 				"node": ">= 14.0.0",
@@ -72,7 +72,7 @@
 			"requires": {
 				"@jazzer.js/hooking": "*",
 				"@jazzer.js/instrumentor": "*",
-				"@types/yargs": "^17.0.13",
+				"@types/yargs": "^17.0.14",
 				"yargs": "^17.6.2"
 			}
 		},

--- a/packages/jest-runner/fuzz.ts
+++ b/packages/jest-runner/fuzz.ts
@@ -53,7 +53,16 @@ export const fuzz: FuzzTest = (title, fuzzTest) => {
 
 	if (fuzzingConfig.dryRun) {
 		g.describe(title, () => {
-			corpus.inputPaths().forEach(([name, path]) => {
+			const inputsPaths = corpus.inputsPaths();
+			// Mark fuzz tests with empty inputs as skipped to suppress
+			// Jest error.
+			if (inputsPaths.length === 0) {
+				g.test.skip(title, () => {
+					return;
+				});
+				return;
+			}
+			inputsPaths.forEach(([name, path]) => {
 				const runOptions = fuzzerOptions.concat(path);
 				const testFn: Global.TestFn = () => {
 					return core.startFuzzingAsyncNoInit(fuzzTest, runOptions);
@@ -62,8 +71,8 @@ export const fuzz: FuzzTest = (title, fuzzTest) => {
 			});
 		});
 	} else {
-		fuzzerOptions.unshift(corpus.inputDirectory);
-		fuzzerOptions.push("-artifact_prefix=" + corpus.outputDirectory);
+		fuzzerOptions.unshift(corpus.inputsDirectory);
+		fuzzerOptions.push("-artifact_prefix=" + corpus.inputsDirectory);
 		const testFn: Global.TestFn = () => {
 			return core.startFuzzingAsyncNoInit(fuzzTest, fuzzerOptions);
 		};


### PR DESCRIPTION
Fuzz tests without seed files are marked as skipped in regression
test. This prevents Jest from displaying an error that no tests could be
found. The input directory structure is still automatically created.