### PR TITLE
Enable dependabot in all npm workspaces

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "npm"
-    directory: "/packages/core"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "npm"
-    directory: "/packages/fuzzer"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "npm"
-    directory: "/packages/instrumentor"
-    schedule:
-      interval: "daily"
+    versioning-strategy: increase


### PR DESCRIPTION
Only configuring the root project should enable Dependabot to check all workspaces. 
Discussed in this issue: https://github.com/dependabot/dependabot-core/issues/4993#issuecomment-1289133027