### PR TITLE
Support source maps

### DIFF
--- a/examples/js-yaml/tsconfig.json
+++ b/examples/js-yaml/tsconfig.json
@@ -12,6 +12,7 @@
 		"strict": true,
 		"skipLibCheck": true,
 		"declaration": true,
-		"composite": true
+		"composite": true,
+		"sourceMap": true
 	}
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,4 +19,6 @@ module.exports = {
 	preset: "ts-jest",
 	testEnvironment: "node",
 	modulePathIgnorePatterns: ["dist", "packages/fuzzer/build"],
+	collectCoverageFrom: ["packages/**/*.ts"],
+	coveragePathIgnorePatterns: ["/node_modules/", "/dist/"],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1260,6 +1260,15 @@
 			"integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
 			"dev": true
 		},
+		"node_modules/@types/source-map-support": {
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.6.tgz",
+			"integrity": "sha512-b2nJ9YyXmkhGaa2b8VLM0kJ04xxwNyijcq12/kDoomCt43qbHBeK2SLNJ9iJmETaAj+bKUT05PQUu3Q66GvLhQ==",
+			"dev": true,
+			"dependencies": {
+				"source-map": "^0.6.0"
+			}
+		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -8390,6 +8399,7 @@
 			"dependencies": {
 				"@jazzer.js/hooking": "*",
 				"@jazzer.js/instrumentor": "*",
+				"source-map-support": "^0.5.21",
 				"yargs": "^17.6.2"
 			},
 			"bin": {
@@ -8401,6 +8411,15 @@
 			"engines": {
 				"node": ">= 14.0.0",
 				"npm": ">= 7.0.0"
+			}
+		},
+		"packages/core/node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"packages/fuzzer": {
@@ -8449,16 +8468,27 @@
 				"@babel/generator": "^7.20.5",
 				"@jazzer.js/fuzzer": "*",
 				"@jazzer.js/hooking": "*",
-				"istanbul-lib-hook": "^3.0.0"
+				"istanbul-lib-hook": "^3.0.0",
+				"source-map-support": "^0.5.21"
 			},
 			"devDependencies": {
 				"@types/babel__core": "^7.1.20",
 				"@types/istanbul-lib-hook": "^2.0.1",
-				"@types/node": "^18.11.18"
+				"@types/node": "^18.11.18",
+				"@types/source-map-support": "^0.5.6"
 			},
 			"engines": {
 				"node": ">= 14.0.0",
 				"npm": ">= 7.0.0"
+			}
+		},
+		"packages/instrumentor/node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"packages/jest": {
@@ -9035,7 +9065,19 @@
 				"@jazzer.js/hooking": "*",
 				"@jazzer.js/instrumentor": "*",
 				"@types/yargs": "^17.0.19",
+				"source-map-support": "^0.5.21",
 				"yargs": "^17.6.2"
+			},
+			"dependencies": {
+				"source-map-support": {
+					"version": "0.5.21",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+					"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					}
+				}
 			}
 		},
 		"@jazzer.js/fuzzer": {
@@ -9068,7 +9110,20 @@
 				"@types/babel__core": "^7.1.20",
 				"@types/istanbul-lib-hook": "^2.0.1",
 				"@types/node": "^18.11.18",
-				"istanbul-lib-hook": "^3.0.0"
+				"@types/source-map-support": "^0.5.6",
+				"istanbul-lib-hook": "^3.0.0",
+				"source-map-support": "^0.5.21"
+			},
+			"dependencies": {
+				"source-map-support": {
+					"version": "0.5.21",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+					"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					}
+				}
 			}
 		},
 		"@jazzer.js/jest-runner": {
@@ -9485,6 +9540,15 @@
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
 			"integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
 			"dev": true
+		},
+		"@types/source-map-support": {
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.6.tgz",
+			"integrity": "sha512-b2nJ9YyXmkhGaa2b8VLM0kJ04xxwNyijcq12/kDoomCt43qbHBeK2SLNJ9iJmETaAj+bKUT05PQUu3Q66GvLhQ==",
+			"dev": true,
+			"requires": {
+				"source-map": "^0.6.0"
+			}
 		},
 		"@types/stack-utils": {
 			"version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"compile:watch": "tsc -b tsconfig.build.json --incremental --pretty --watch",
 		"test": "run-script-os",
 		"test:jest": "jest && npm run test --ws --if-present",
+		"test:coverage": "jest --coverage",
 		"test:default": "npm run test:jest",
 		"test:linux:darwin": "npm run test:jest && cd examples && sh ../scripts/run_all.sh dryRun && cd ../tests && sh ../scripts/run_all.sh fuzz",
 		"test:win32": "npm run test:jest && cd examples && ..\\scripts\\run_all.bat dryRun && cd ..\\tests && ..\\scripts\\run_all.bat fuzz",

--- a/packages/instrumentor/package.json
+++ b/packages/instrumentor/package.json
@@ -20,12 +20,14 @@
 		"@babel/generator": "^7.20.5",
 		"@jazzer.js/fuzzer": "*",
 		"@jazzer.js/hooking": "*",
-		"istanbul-lib-hook": "^3.0.0"
+		"istanbul-lib-hook": "^3.0.0",
+		"source-map-support": "^0.5.21"
 	},
 	"devDependencies": {
 		"@types/babel__core": "^7.1.20",
 		"@types/istanbul-lib-hook": "^2.0.1",
-		"@types/node": "^18.11.18"
+		"@types/node": "^18.11.18",
+		"@types/source-map-support": "^0.5.6"
 	},
 	"engines": {
 		"node": ">= 14.0.0",

--- a/tests/string_compare/package.json
+++ b/tests/string_compare/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"description": "An example showing how Jazzer.js handles string comparisons in the code",
 	"scripts": {
-		"fuzz": "jazzer fuzz --sync  -x Error -- -max_total_time=60",
+		"fuzz": "jazzer fuzz --sync -x Error -- -max_total_time=60",
 		"dryRun": "jazzer fuzz --sync -- -runs=100 -seed=123456789"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Jazzer's instrumentation dynamically adds code to loaded files to track progress/coverage and in doing so messes up error stack traces. This PR enables the creation of source maps and subsequent cleanup of error stack traces.

The internal source map support of Node.js can not be used, as the code is instrumented during runtime and the generated source maps can not be passed to node.