### PR TITLE
Fix default includes/excludes in Jest integration

### DIFF
--- a/fuzztests/instrument.fuzz.js
+++ b/fuzztests/instrument.fuzz.js
@@ -33,8 +33,8 @@ describe("instrument", () => {
 
 		const check = shouldInstrumentFn(includes, excludes);
 
-		const includeAll = includes.some((e) => e === "");
-		const excludeAll = excludes.some((e) => e === "");
+		const includeAll = includes.some((e) => e === "*");
+		const excludeAll = excludes.some((e) => e === "*");
 
 		if (excludeAll) {
 			expect(check).toBeFalsy();

--- a/packages/core/cli.ts
+++ b/packages/core/cli.ts
@@ -160,14 +160,8 @@ yargs(process.argv.slice(2))
 			startFuzzing({
 				fuzzTarget: ensureFilepath(args.fuzzTarget),
 				fuzzEntryPoint: args.fuzzFunction,
-				includes: args.instrumentation_includes.map((include: string) =>
-					// empty string matches every file
-					include === "*" ? "" : include
-				),
-				excludes: args.instrumentation_excludes.map((exclude: string) =>
-					// empty string matches every file
-					exclude === "*" ? "" : exclude
-				),
+				includes: args.instrumentation_includes,
+				excludes: args.instrumentation_excludes,
 				dryRun: args.dry_run,
 				sync: args.sync,
 				fuzzerOptions: args.corpus.concat(args._),

--- a/packages/instrumentor/instrument.test.ts
+++ b/packages/instrumentor/instrument.test.ts
@@ -33,14 +33,23 @@ describe("shouldInstrument check", () => {
 		expect(check("/something/else")).toBeFalsy();
 	});
 
-	it("should include everything with emptystring", () => {
-		const check = shouldInstrumentFn([""], []);
+	it("should include everything with *", () => {
+		const check = shouldInstrumentFn(["*"], []);
 		expect(check("include")).toBeTruthy();
 		expect(check("/something/else")).toBeTruthy();
 	});
 
+	it("should include nothing with emtpy string", () => {
+		const emtpyInclude = shouldInstrumentFn(["include", ""], []);
+		expect(emtpyInclude("include")).toBeTruthy();
+		expect(emtpyInclude("/something/else")).toBeFalsy();
+		const emtpyExclude = shouldInstrumentFn(["include"], [""]);
+		expect(emtpyExclude("include")).toBeTruthy();
+		expect(emtpyExclude("/something/else")).toBeFalsy();
+	});
+
 	it("should exclude with precedence", () => {
-		const check = shouldInstrumentFn(["include"], [""]);
+		const check = shouldInstrumentFn(["include"], ["*"]);
 		expect(check("/some/package/include/files")).toBeFalsy();
 	});
 });

--- a/packages/instrumentor/instrument.ts
+++ b/packages/instrumentor/instrument.ts
@@ -93,11 +93,19 @@ export function shouldInstrumentFn(
 	includes: string[],
 	excludes: string[]
 ): FilePredicate {
+	const cleanup = (settings: string[]) =>
+		settings
+			.filter((setting) => setting)
+			.map((setting) => (setting === "*" ? "" : setting)); // empty string matches every file
+	const cleanedIncludes = cleanup(includes);
+	const cleanedExcludes = cleanup(excludes);
 	return (filepath: string) => {
 		const included =
-			includes.find((include) => filepath.includes(include)) !== undefined;
+			cleanedIncludes.find((include) => filepath.includes(include)) !==
+			undefined;
 		const excluded =
-			excludes.find((exclude) => filepath.includes(exclude)) !== undefined;
+			cleanedExcludes.find((exclude) => filepath.includes(exclude)) !==
+			undefined;
 		return included && !excluded;
 	};
 }


### PR DESCRIPTION
The Jest integration should also use the same default include/exclude pattern as the standalone version. Any "cleanup" or translation of the settings has to be applied for both cases.