### PR TITLE
Introduce toggle for FuzzedDataProvider to only return printable strings

### DIFF
--- a/packages/core/FuzzedDataProvider.test.ts
+++ b/packages/core/FuzzedDataProvider.test.ts
@@ -945,6 +945,24 @@ describe("FuzzedDataProvider checks", () => {
 		expect(strings).toContain("or si");
 		expect(strings).toContain("t ame");
 	});
+	it("verifyPrintableString", () => {
+		const data = new FuzzedDataProvider(Buffer.from(Data));
+		const consumedStrAsArr = [...data.consumeString(1024, "ascii", true)];
+		consumedStrAsArr.forEach((c) => {
+			const charAsNum = c.charCodeAt(0);
+			expect(charAsNum >= 32 && charAsNum <= 126).toBeTruthy();
+		});
+	});
+	it("verifyNonPrintableString", () => {
+		const data = new FuzzedDataProvider(Buffer.from(Data));
+		const consumedStrAsArr = [...data.consumeString(1024)];
+		expect(
+			consumedStrAsArr.some((ele) => {
+				const eleAsNum = ele.charCodeAt(0);
+				return eleAsNum < 32 || eleAsNum > 126;
+			})
+		).toBeTruthy();
+	});
 });
 
 const Data = Buffer.from([


### PR DESCRIPTION
The change aims at being able to toggle this individually for each time we call a `ConsumeStr*` method, which would allow us to pass lossy strings and proper ASCII strings as function inputs, instead of globally toggling ASCII-only mutations by setting the appropriate libfuzzer flag and/or using the constructor for the FuzzedDataProvider

Instead of just filtering out non-printable ones and having to re-read from the data buffer (multiple times) I opted for a (hopefully lightweight) conversion, so that each non-printable one is converted into a printable one.

