### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/fuzz-targets.md
+++ b/docs/fuzz-targets.md
@@ -121,7 +121,7 @@ export function fuzz(data: Buffer) {
 	try {
 		// Fuzz logic
 	} catch (e) {
-		// Handle expected error ogic here
+		// Handle expected error logic here
 	}
 }
 ```


### PR DESCRIPTION
I just saw this during your demo in the Sprint Review today (which was really awesome BTW! :clap:)