### PR TITLE
Handle libFuzzer modes that spawn subprocesses

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
 	"dependencies": {
 		"@jazzer.js/hooking": "*",
 		"@jazzer.js/instrumentor": "*",
+		"tmp": "^0.2.1",
 		"yargs": "^17.6.2"
 	},
 	"devDependencies": {

--- a/packages/fuzzer/utils.cpp
+++ b/packages/fuzzer/utils.cpp
@@ -17,12 +17,7 @@
 
 void StartLibFuzzer(const std::vector<std::string> &args,
                     fuzzer::UserCallback fuzzCallback) {
-  // Prepare a fake command line and start the fuzzer. This is made
-  // slightly awkward by the fact that libfuzzer requires the string data
-  // to be mutable and expects a C-style array of pointers.
-  std::string progname{"jazzer"};
   std::vector<char *> fuzzer_arg_pointers;
-  fuzzer_arg_pointers.push_back(progname.data());
   for (auto &arg : args)
     fuzzer_arg_pointers.push_back((char *)arg.data());
 

--- a/tests/fork_mode/fuzz.js
+++ b/tests/fork_mode/fuzz.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @param { Buffer } data
+ */
+module.exports.fuzz = function (data) {
+	if (data.toString() === "fork mode") {
+		throw new Error("crash when fuzzing in fork mode!");
+	}
+};

--- a/tests/fork_mode/package.json
+++ b/tests/fork_mode/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "jazzerjs-fork-mode-example",
+	"version": "1.0.0",
+	"description": "An example showing how to use libFuzzer's fork mode in Jazzer.js",
+	"scripts": {
+		"fuzz": "jazzer fuzz --sync -- -fork=3",
+		"dryRun": "jazzer fuzz -d --sync -- -fork=3 -runs=100 -seed=123456789"
+	},
+	"devDependencies": {
+		"@jazzer.js/core": "file:../../packages/core"
+	}
+}


### PR DESCRIPTION
When we run in a libFuzzer mode that spawns subprocesses, we create wrapper script that can be used as libFuzzer's argv[0]. In the fork mode, the main libFuzzer process uses argv[0] to spawn further processes that perform the actual fuzzing.