### PR TITLE
Build M1 mac artifacts in release pipeline

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -32,11 +32,15 @@ jobs:
 
   prebuilds:
     name: create prebuilds
-    runs-on: ${{ matrix.os }}
     needs: [create_release]
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2019]
+        opts: [""]
+        include:
+          - os: macos-11
+            opts: "--arch arm64"
+    runs-on: ${{ matrix.os }}
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -52,5 +56,5 @@ jobs:
         run: npm install --ws=@jazzer.js/fuzzer
       - name: build and upload prebuilds
         run: >
-          npm run upload --workspace=@jazzer.js/fuzzer --
-          ${{secrets.GITHUB_TOKEN}}
+          npm run prebuild --workspace=@jazzer.js/fuzzer -- ${{ matrix.opts }}
+          --upload ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -45,19 +45,6 @@ jobs:
         with:
           node-version: 16
           cache: "npm"
-      - name: install dependencies (macos)
-        if: contains(matrix.os, 'macos')
-        run: |
-          brew install cmake llvm@14
-          LLVM_PATH=$(brew --prefix llvm@14)
-          LLVM_CONFIG_PATH=$LLVM_PATH/bin/llvm-config
-          echo "CC=$($LLVM_CONFIG_PATH --bindir)/clang" >> $GITHUB_ENV
-          echo "CXX=$($LLVM_CONFIG_PATH --bindir)/clang++" >> $GITHUB_ENV
-          echo "CFLAGS=$($LLVM_CONFIG_PATH --cflags)" >> $GITHUB_ENV 
-          echo "CXXFLAGS=$($LLVM_CONFIG_PATH --cxxflags)" >> $GITHUB_ENV 
-          echo "LDFLAGS=$($LLVM_CONFIG_PATH --ldflags)" >> $GITHUB_ENV
-          echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
-          echo "PATH=$PATH:$($LLVM_CONFIG_PATH --bindir)" >> $GITHUB_ENV
       - name: MSVC (windows)
         uses: ilammy/msvc-dev-cmd@d8610e2b41c6d0f0c3b4c46dad8df0fd826c68e1
         if: contains(matrix.os, 'windows')

--- a/.github/workflows/run-all-tests.yaml
+++ b/.github/workflows/run-all-tests.yaml
@@ -41,18 +41,6 @@ jobs:
         with:
           node-version: 16
           cache: "npm"
-      - name: install dependencies (macos)
-        if: contains(matrix.os, 'macos')
-        run: |
-          brew install cmake llvm@14
-          LLVM_PATH=$(brew --prefix llvm@14)
-          LLVM_CONFIG_PATH=$LLVM_PATH/bin/llvm-config
-          echo "CC=$($LLVM_CONFIG_PATH --bindir)/clang" >> $GITHUB_ENV
-          echo "CXX=$($LLVM_CONFIG_PATH --bindir)/clang++" >> $GITHUB_ENV
-          echo "CFLAGS=$($LLVM_CONFIG_PATH --cflags)" >> $GITHUB_ENV 
-          echo "CXXFLAGS=$($LLVM_CONFIG_PATH --cxxflags)" >> $GITHUB_ENV 
-          echo "LDFLAGS=$($LLVM_CONFIG_PATH --ldflags)" >> $GITHUB_ENV
-          echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
       - name: MSVC (windows)
         uses: ilammy/msvc-dev-cmd@v1
         if: contains(matrix.os, 'windows')

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+jazzer_js_fuzzer_local_prebuilds=prebuilds/@jazzer.js/

--- a/docs/release.md
+++ b/docs/release.md
@@ -5,15 +5,15 @@ To release a new version of Jazzer.js follow the described process:
 1. Create a release PR
    - Update the version numbers in `package.json` for the root and sub-modules  
      Version numbers are based on [Semantic Versioning](https://semver.org)
-   - Add other release relevant changes, like adding release specific docs etc
+   - Add other release relevant changes, like adding release specific docs etc.
 2. Approve and merge the release PR
 3. Create and push a version tag on the latest commit of the release
    - Tag format `v<new-version-number>`, e.g. `v1.0.0`
 4. Wait until the `Prerelease` GitHub action workflow has finished successfully
-   - The workflow will create a GitHub pre-release based on the tag
-   - It adds prebuild artifacts of all supported platforms to it
-   - An automatic changelog based on the included merge requests added to the
-     prerelease description
+   - The workflow creates a GitHub prerelease based on the created tag
+   - It adds prebuild artifacts of all supported platforms
+   - An automatic changelog, based on the included merge requests, is added to
+     the prerelease description
    - The prerelease is listed on the
      [release page](https://github.com/CodeIntelligenceTesting/jazzer.js/releases)
 5. Release the prerelease in GitHub
@@ -25,4 +25,4 @@ To release a new version of Jazzer.js follow the described process:
 6. Wait until the `Release` GitHub action workflow has finished successfully
    - The workflow will build and publish the
      [NPM packages](https://www.npmjs.com/package/@jazzer.js/core).
-7. Enjoy the rest of your day
+7. Enjoy the rest of your day 🎂

--- a/packages/fuzzer/README.md
+++ b/packages/fuzzer/README.md
@@ -16,8 +16,8 @@ what users want, so that their JS fuzz target can run in its normal environment.
 The project can be built with `npm run build` (which is incremental after the
 first build); a subsequent `npm test` makes sure that the addon loads cleanly.
 Binaries can be prebuilt with `npm run prebuild` and uploaded with
-`npm run upload`. Please format the code with `clang-format` (or use the format
-functionality of `clangd`).
+`npm run prebuild -- --upload`. Please format the code with `clang-format` (or
+use the format functionality of `clangd`).
 
 Internally, the build system uses several steps:
 

--- a/packages/fuzzer/package.json
+++ b/packages/fuzzer/package.json
@@ -17,7 +17,7 @@
 	"types": "dist/fuzzer.d.ts",
 	"scripts": {
 		"prebuild": "prebuild --runtime napi --backend cmake-js --all --strip --verbose",
-		"install": "prebuild-install --runtime napi || cmake-js rebuild --out build",
+		"install": "prebuild-install --runtime napi || npm run prebuild",
 		"build": "cmake-js build --out build",
 		"format:fix": "clang-format -i *.cpp shared/*.cpp shared/*.h",
 		"lint": "find . -path ./build -prune -type f -o -iname '*.h' -o -iname '*.cpp' | xargs clang-tidy"

--- a/packages/fuzzer/package.json
+++ b/packages/fuzzer/package.json
@@ -17,7 +17,6 @@
 	"types": "dist/fuzzer.d.ts",
 	"scripts": {
 		"prebuild": "prebuild --runtime napi --backend cmake-js --all --strip --verbose",
-		"upload": "prebuild --runtime napi --backend cmake-js --all --strip --upload",
 		"install": "prebuild-install --runtime napi || cmake-js rebuild --out build",
 		"build": "cmake-js build --out build",
 		"format:fix": "clang-format -i *.cpp shared/*.cpp shared/*.h",


### PR DESCRIPTION
This PR adds the build of M1 mac (arm64) fuzzer artifacts to the release pipeline. These artifacts can be downloaded later on during normal installation of the project.

Furthermore, no special compiler configuration is necessary anymore on macs.

The pipelines can only finally be tested once the PR is merged.