### PR TITLE
ci: build the native addon in the linting step

### DIFF
--- a/.github/workflows/run-all-tests.yaml
+++ b/.github/workflows/run-all-tests.yaml
@@ -25,6 +25,9 @@ jobs:
           sudo apt-get install clang-tidy-15
           sudo rm -f /usr/bin/clang-tidy
           sudo ln -s /usr/bin/clang-tidy-15 /usr/bin/clang-tidy
+      - name: build fuzzer
+        # Build the native addon so that CMake generates compile_commands.json that is needed by clang-tidy
+        run: npm run build --workspace=@jazzer.js/fuzzer
       - name: check formatting and linting
         run: npm run check
   unit_tests:


### PR DESCRIPTION
This is needed so that CMake generates compile_commands.json, which is needed by clang-tidy