### PR TITLE
Add missing `core` dependency in `jest-runner`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7143,7 +7143,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dev": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -7722,7 +7721,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
 			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-			"dev": true,
 			"dependencies": {
 				"rimraf": "^3.0.0"
 			},
@@ -8399,6 +8397,7 @@
 			"dependencies": {
 				"@jazzer.js/hooking": "*",
 				"@jazzer.js/instrumentor": "*",
+				"tmp": "^0.2.1",
 				"yargs": "^17.6.2"
 			},
 			"bin": {
@@ -8498,6 +8497,7 @@
 			"version": "1.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@jazzer.js/core": "*",
 				"cosmiconfig": "^8.0.0",
 				"jest": "^29.3.1"
 			},
@@ -9055,6 +9055,7 @@
 				"@jazzer.js/hooking": "*",
 				"@jazzer.js/instrumentor": "*",
 				"@types/yargs": "^17.0.20",
+				"tmp": "^0.2.1",
 				"yargs": "^17.6.2"
 			}
 		},
@@ -9107,6 +9108,7 @@
 		"@jazzer.js/jest-runner": {
 			"version": "file:packages/jest-runner",
 			"requires": {
+				"@jazzer.js/core": "*",
 				"@types/tmp": "^0.2.3",
 				"cosmiconfig": "^8.0.0",
 				"jest": "^29.3.1",
@@ -14036,7 +14038,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -14436,7 +14437,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
 			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-			"dev": true,
 			"requires": {
 				"rimraf": "^3.0.0"
 			}

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -16,6 +16,7 @@
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"dependencies": {
+		"@jazzer.js/core": "*",
 		"cosmiconfig": "^8.0.0",
 		"jest": "^29.3.1"
 	},


### PR DESCRIPTION
Add a dependency on `@jazzer.js/core` in `@jazzer.js/jest-runner`, so that no additional one is required to execute fuzz tests.