### PR TITLE
Change Jazzer.js fuzz tests to fixed number of runs

### DIFF
--- a/examples/jest_integration/.jazzerjsrc.json
+++ b/examples/jest_integration/.jazzerjsrc.json
@@ -1,5 +1,5 @@
 {
 	"includes": ["target", "integration.fuzz", "worker.fuzz"],
 	"excludes": ["node_modules"],
-	"fuzzerOptions": ["-rss_limit_mb=16000"]
+	"fuzzerOptions": ["-rss_limit_mb=16000", "-runs=100000"]
 }

--- a/fuzztests/.jazzerjsrc
+++ b/fuzztests/.jazzerjsrc
@@ -1,5 +1,5 @@
 {
-	"fuzzerOptions": ["-use_value_profile=1", "-max_total_time=30"],
+	"fuzzerOptions": ["-use_value_profile=1", "-runs=100000"],
 	"includes": ["jazzer.js"],
 	"timeout": 1000
 }

--- a/tests/FuzzedDataProvider/package.json
+++ b/tests/FuzzedDataProvider/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"description": "An example showing how to use FuzzedDataProvider in Jazzer.js",
 	"scripts": {
-		"fuzz": "jazzer fuzz --sync -x Error -i jazzer.js -- -use_value_profile=1 -print_pcs=1 -print_final_stats=1 -max_len=52 -max_total_time=180 -seed=123",
+		"fuzz": "jazzer fuzz --sync -x Error -i jazzer.js -- -use_value_profile=1 -print_pcs=1 -print_final_stats=1 -max_len=52 -runs=4000000 -seed=605643277",
 		"dryRun": "jazzer fuzz -d --sync -- -runs=100 -seed=123456789"
 	},
 	"devDependencies": {

--- a/tests/done_callback/package.json
+++ b/tests/done_callback/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"description": "An example showing how Jazzer.js handles callback based fuzz targets",
 	"scripts": {
-		"fuzz": "jazzer fuzz -x Error -- -max_total_time=60",
+		"fuzz": "jazzer fuzz -x Error -- -runs=5000 -seed=2386907168",
 		"dryRun": "jazzer fuzz -- -runs=100 -seed=123456789"
 	},
 	"devDependencies": {

--- a/tests/return_values/asyncRunnerAsyncReturns/package.json
+++ b/tests/return_values/asyncRunnerAsyncReturns/package.json
@@ -3,8 +3,8 @@
 	"version": "1.0.0",
 	"description": "An example showing how Jazzer.js handles string comparisons in the code",
 	"scripts": {
-		"fuzz": "jazzer fuzz  -- -max_total_time=60",
-		"dryRun": "jazzer fuzz -- -runs=100 -seed=123456789 "
+		"fuzz": "jazzer fuzz  -- -runs=5000 -seed=3088388356",
+		"dryRun": "jazzer fuzz -- -runs=100 -seed=123456789"
 	},
 	"devDependencies": {
 		"@jazzer.js/core": "file:../../../packages/core"

--- a/tests/return_values/asyncRunnerMixedReturns/package.json
+++ b/tests/return_values/asyncRunnerMixedReturns/package.json
@@ -3,8 +3,8 @@
 	"version": "1.0.0",
 	"description": "An example showing how Jazzer.js handles string comparisons in the code",
 	"scripts": {
-		"fuzz": "jazzer fuzz  -- -max_total_time=60 ",
-		"dryRun": "jazzer fuzz -- -runs=100 -seed=123456789 "
+		"fuzz": "jazzer fuzz  -- -runs=5000 -seed=3088388356",
+		"dryRun": "jazzer fuzz -- -runs=100 -seed=123456789"
 	},
 	"devDependencies": {
 		"@jazzer.js/core": "file:../../../packages/core"

--- a/tests/return_values/asyncRunnerSyncReturns/package.json
+++ b/tests/return_values/asyncRunnerSyncReturns/package.json
@@ -3,8 +3,8 @@
 	"version": "1.0.0",
 	"description": "An example showing how Jazzer.js handles string comparisons in the code",
 	"scripts": {
-		"fuzz": "jazzer fuzz  -- -max_total_time=60 ",
-		"dryRun": "jazzer fuzz -- -runs=100 -seed=123456789 "
+		"fuzz": "jazzer fuzz  -- -runs=5000 -seed=3088388356",
+		"dryRun": "jazzer fuzz -- -runs=100 -seed=123456789"
 	},
 	"devDependencies": {
 		"@jazzer.js/core": "file:../../../packages/core"

--- a/tests/return_values/syncRunnerAsyncReturns/package.json
+++ b/tests/return_values/syncRunnerAsyncReturns/package.json
@@ -3,8 +3,8 @@
 	"version": "1.0.0",
 	"description": "An example showing how Jazzer.js handles string comparisons in the code",
 	"scripts": {
-		"fuzz": "jazzer fuzz --sync  -- -max_total_time=60 ",
-		"dryRun": "jazzer fuzz --sync -- -runs=100 -seed=123456789 "
+		"fuzz": "jazzer fuzz --sync  -- -runs=5000 -seed=3088388356",
+		"dryRun": "jazzer fuzz --sync -- -runs=100 -seed=123456789"
 	},
 	"devDependencies": {
 		"@jazzer.js/core": "file:../../../packages/core"

--- a/tests/return_values/syncRunnerMixedReturns/package.json
+++ b/tests/return_values/syncRunnerMixedReturns/package.json
@@ -3,8 +3,8 @@
 	"version": "1.0.0",
 	"description": "An example showing how Jazzer.js handles string comparisons in the code",
 	"scripts": {
-		"fuzz": "jazzer fuzz --sync  -- -max_total_time=60 ",
-		"dryRun": "jazzer fuzz -- -runs=100 -seed=123456789 "
+		"fuzz": "jazzer fuzz --sync  -- -runs=5000 -seed=3088388356",
+		"dryRun": "jazzer fuzz -- -runs=100 -seed=123456789"
 	},
 	"devDependencies": {
 		"@jazzer.js/core": "file:../../../packages/core"

--- a/tests/return_values/syncRunnerSyncReturns/package.json
+++ b/tests/return_values/syncRunnerSyncReturns/package.json
@@ -3,8 +3,8 @@
 	"version": "1.0.0",
 	"description": "An example showing how Jazzer.js handles string comparisons in the code",
 	"scripts": {
-		"fuzz": "jazzer fuzz --sync  -- -max_total_time=60 ",
-		"dryRun": "jazzer fuzz -- -runs=100 -seed=123456789 "
+		"fuzz": "jazzer fuzz --sync  -- -runs=5000 -seed=3088388356",
+		"dryRun": "jazzer fuzz -- -runs=100 -seed=123456789"
 	},
 	"devDependencies": {
 		"@jazzer.js/core": "file:../../../packages/core",

--- a/tests/string_compare/package.json
+++ b/tests/string_compare/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"description": "An example showing how Jazzer.js handles string comparisons in the code",
 	"scripts": {
-		"fuzz": "jazzer fuzz --sync -x Error -- -max_total_time=60",
+		"fuzz": "jazzer fuzz --sync -x Error -- -runs=1000000 -seed=111994470",
 		"dryRun": "jazzer fuzz --sync -- -runs=100 -seed=123456789"
 	},
 	"devDependencies": {

--- a/tests/switch/package.json
+++ b/tests/switch/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"description": "An example showing how Jazzer.js handles switch statements",
 	"scripts": {
-		"fuzz": "jazzer fuzz --sync -x Error -- -max_total_time=60,",
+		"fuzz": "jazzer fuzz --sync -x Error -- -runs=2000000 -seed=1148448756",
 		"dryRun": "jazzer fuzz --sync -- -runs=100 -seed=123456789"
 	},
 	"devDependencies": {

--- a/tests/timeout/package.json
+++ b/tests/timeout/package.json
@@ -3,8 +3,8 @@
 	"version": "1.0.0",
 	"description": "Timeout test: checking that the handler for the SIGALRM signal does not return with error code.",
 	"scripts": {
-		"timeout": "jazzer fuzz -f=timeout --timeout=1000 -- -max_total_time=10",
-		"fuzz": "jazzer fuzz --timeout=1000 -- -max_total_time=10",
+		"timeout": "jazzer fuzz -f=timeout --timeout=1000 -- -runs=5000 -seed=1234",
+		"fuzz": "jazzer fuzz --timeout=1000 -- -runs=5000 -seed=1234",
 		"dryRun": "echo \"skipped\""
 	},
 	"devDependencies": {

--- a/tests/value_profiling/package.json
+++ b/tests/value_profiling/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"description": "An example showing how Jazzer.js handles integer comparisons in the code",
 	"scripts": {
-		"fuzz": "jazzer fuzz --sync -x Error -- -max_total_time=60 -use_value_profile=1",
+		"fuzz": "jazzer fuzz --sync -x Error -- -runs=4000000 -seed=1428686921 -use_value_profile=1",
 		"dryRun": "jazzer fuzz --sync -- -use_value_profile=1 -runs=100 -seed=123456789"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Trying to speed up CI runs by limiting the number of runs. Doesn't seem to have much of an impact (maybe 2–3 minutes shaved off for the fuzz test runner). The main waste of time happens on the Windows/macOS runner when building the native part each time. Caching builds seems to be the one factor that could be quite beneficial. I played around with this already, but couldn't make it work quite yet (FUZZ-575... branch).

Note: It's worth noting that we could reduce the number of runs to e.g. 10000 to lower the runtime even more, that said with 10k runs the fuzz test failed as they expect an error in some cases and as long as we don't fix the Windows/macOS runner it's wasted time.