### PR TITLE
Switch to fixed number of runs in flaky promise test

### DIFF
--- a/tests/promise/package.json
+++ b/tests/promise/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"description": "An example showing how Jazzer.js handles promise based fuzz targets",
 	"scripts": {
-		"fuzz": "jazzer fuzz --fuzz_function fuzz_promise -x Error -- -max_total_time=60",
+		"fuzz": "jazzer fuzz --fuzz_function fuzz_promise -x Error -- -runs=5000 -seed=3088388356",
 		"dryRun": "jazzer fuzz --fuzz_function fuzz_promise -- -runs=1 -seed=123456789"
 	},
 	"devDependencies": {


### PR DESCRIPTION
The now given seed failed in CI after 60s, regardless of the low number
of required iterations (425 on my system), even though the time should
be enough. A few random runs resulted in required iterations lower
3k (on my system), so that 5k should be way enough with the fixed
seed.