### PR TITLE
Approve and merge all but major version updates

### DIFF
--- a/.github/workflows/run-all-tests.yaml
+++ b/.github/workflows/run-all-tests.yaml
@@ -91,10 +91,18 @@ jobs:
         uses: dependabot/fetch-metadata@v1.1.1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Enable auto-merge for Dependabot PRs
+      - name: Approve
         if:
-          ${{steps.metadata.outputs.update-type ==
-          'version-update:semver-patch'}}
+          ${{steps.metadata.outputs.update-type !=
+          'version-update:semver-major'}}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge
+        if:
+          ${{steps.metadata.outputs.update-type !=
+          'version-update:semver-major'}}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
The previous CI changes for Depandabot didn't fix all issues. This PR also enables approve and merge of all but major version updates.