### PR TITLE
improve CI build times by limiting runs

### DIFF
--- a/tests/string_compare/package.json
+++ b/tests/string_compare/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"description": "An example showing how Jazzer.js handles string comparisons in the code",
 	"scripts": {
-		"fuzz": "jazzer fuzz --sync -x Error -- -runs=1000000 -seed=111994470",
+		"fuzz": "jazzer fuzz --sync -x Error -- -runs=5000000 -seed=111994470",
 		"dryRun": "jazzer fuzz --sync -- -runs=100 -seed=123456789"
 	},
 	"devDependencies": {


### PR DESCRIPTION
It seems like the randomness of a fuzzing run and the generally slower CI makes some runs really unpredictable. The `string_compare` example seems to be one of them. Bumping up the runs in the hope to fix the flakiness. Offline 100-200k runs were sufficient in 95% of the time, so the initial upper limit of 1 million was deemed enough. However, #335 failed to succeed