### PR TITLE
bump version of dependabot/fetch-metadata

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -50,7 +50,7 @@ jobs:
           node-version: 16
           cache: "npm"
       - name: MSVC (windows)
-        uses: ilammy/msvc-dev-cmd@d8610e2b41c6d0f0c3b4c46dad8df0fd826c68e1
+        uses: ilammy/msvc-dev-cmd@v1
         if: contains(matrix.os, 'windows')
       - name: install dependencies
         run: npm install --ws=@jazzer.js/fuzzer

--- a/.github/workflows/run-all-tests.yaml
+++ b/.github/workflows/run-all-tests.yaml
@@ -88,7 +88,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.1.1
+        uses: dependabot/fetch-metadata@v1.3.6
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve


### PR DESCRIPTION
This should get rid of one warning in the CI that Node 12 is deprecated, as the new Dependabot now uses Node16.
The change to the `prerelease.yml` aligns the actions with the one used in the test action as well.