### PR TITLE
Note Jest Typescript limitation

### DIFF
--- a/docs/jest-integration.md
+++ b/docs/jest-integration.md
@@ -334,3 +334,4 @@ reimplemented.
 
 - Mock functions
 - Isolated workers
+- Typescript or any other non-Javascript test files


### PR DESCRIPTION
While debugging the CI issues with #327, we realized that getting our runner to support tests written in Typescript is going to be a very large task so we're going to close the other PR and add a note that this doesn't work yet.