### PR TITLE
Demote jest to a dev dependency

### DIFF
--- a/packages/core/cli.ts
+++ b/packages/core/cli.ts
@@ -98,7 +98,7 @@ yargs(process.argv.slice(2))
 						"Part of filepath names to include in the instrumentation. " +
 						'A tailing "/" should be used to include directories and prevent ' +
 						'confusion with filenames. "*" can be used to include all files.\n' +
-						"Can be specified multiple times. By default all files will be" +
+						"Can be specified multiple times. By default all files will be " +
 						"included.",
 					type: "string",
 					alias: "i",
@@ -111,7 +111,7 @@ yargs(process.argv.slice(2))
 						"Part of filepath names to exclude in the instrumentation. " +
 						'A tailing "/" should be used to exclude directories and prevent ' +
 						'confusion with filenames. "*" can be used to exclude all files.\n' +
-						'Can be specified multiple times. By default, "node_modules/" will' +
+						'Can be specified multiple times. By default, "node_modules/" will ' +
 						"be excluded.",
 					type: "string",
 					alias: "e",

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -18,10 +18,10 @@
 	"dependencies": {
 		"@jazzer.js/core": "*",
 		"cosmiconfig": "^8.1.0",
-		"jest": "^29.5.0",
 		"istanbul-reports": "^3.1.5"
 	},
 	"devDependencies": {
+		"jest": "^29.5.0",
 		"@types/istanbul-reports": "^3.0.1",
 		"@types/tmp": "^0.2.3",
 		"tmp": "^0.2.1"


### PR DESCRIPTION
so users are free to use their preferred version of Jest on their system.