### PR TITLE
bugfix: deep-copy default Jest config

### DIFF
--- a/packages/jest-runner/config.test.ts
+++ b/packages/jest-runner/config.test.ts
@@ -28,5 +28,12 @@ describe("Config", () => {
 			expect(config.includes).toContain("target");
 			expect(config.excludes).toContain("nothing");
 		});
+
+		it("configs are deep copied", () => {
+			const config1 = loadConfig();
+			config1.fuzzerOptions.push("-runs=100");
+			const config2 = loadConfig("merge-test-jazzerjs");
+			expect(config1.fuzzerOptions).not.toEqual(config2.fuzzerOptions);
+		});
 	});
 });

--- a/packages/jest-runner/config.ts
+++ b/packages/jest-runner/config.ts
@@ -38,9 +38,10 @@ export const defaultOptions: Options = {
 // within different configuration files.
 export function loadConfig(optionsKey = "jazzerjs"): Options {
 	const result = cosmiconfigSync(optionsKey).search();
+	const defaultOptionsCopy = JSON.parse(JSON.stringify(defaultOptions));
 	let config;
 	if (result === null) {
-		config = { ...defaultOptions };
+		config = defaultOptionsCopy;
 	} else {
 		config = Object.keys(defaultOptions).reduce(
 			(config: Options, key: string) => {
@@ -49,7 +50,7 @@ export function loadConfig(optionsKey = "jazzerjs"): Options {
 				}
 				return config;
 			},
-			defaultOptions
+			defaultOptionsCopy
 		);
 	}
 


### PR DESCRIPTION
This fixes the bug where a Jest-fuzztest would write a crash file into the directory of another Jest-fuzztest. The bug was due to 1) each test adds --artifact_prefix=... to its copy of the options, 2) the copy provided to each test was a shallow-copy of `defaultOptions`. Making deep copies of the default options fixes this problem.