### PR TITLE
Fix async bug detector wrapper

### DIFF
--- a/tests/bug-detectors/bug-detectors.test.js
+++ b/tests/bug-detectors/bug-detectors.test.js
@@ -37,7 +37,7 @@ describe("General tests", () => {
 
 	it("Call with EVIL string; ASYNC", () => {
 		const fuzzTest = new FuzzTestBuilder()
-			.sync(false)
+			.runs(0)
 			.fuzzEntryPoint("CallOriginalEvilAsync")
 			.dir(bugDetectorDirectory)
 			.build();


### PR DESCRIPTION
Await the execution of returned promises in the async bug detector wrapper, as otherwise findings would only be thrown in the next invocation.