### PR TITLE
Configure eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,12 @@
 	],
 	"overrides": [
 		{
+			"files": ["*.js", "*.ts"],
+			"rules": {
+				"@typescript-eslint/no-var-requires": "off"
+			}
+		},
+		{
 			"files": ["*.md"],
 			"parser": "eslint-plugin-markdownlint/parser",
 			"extends": ["plugin:markdownlint/recommended"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,8 @@
 		{
 			"files": ["*.js", "*.ts"],
 			"rules": {
-				"@typescript-eslint/no-var-requires": "off"
+				"@typescript-eslint/no-var-requires": "off",
+				"@typescript-eslint/ban-ts-comment": "off"
 			}
 		},
 		{

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,10 @@
 {
 	"root": true,
 	"parser": "@typescript-eslint/parser",
-	"plugins": ["@typescript-eslint"],
+	"plugins": ["@typescript-eslint", "jest"],
 	"env": {
-		"node": true
+		"node": true,
+		"jest/globals": true
 	},
 	"extends": [
 		"eslint:recommended",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,8 @@
 			"files": ["*.js", "*.ts"],
 			"rules": {
 				"@typescript-eslint/no-var-requires": "off",
-				"@typescript-eslint/ban-ts-comment": "off"
+				"@typescript-eslint/ban-ts-comment": "off",
+				"@typescript-eslint/no-unused-vars": "off"
 			}
 		},
 		{

--- a/examples/bug-detectors/command-injection/custom-hooks.js
+++ b/examples/bug-detectors/command-injection/custom-hooks.js
@@ -16,7 +16,7 @@
  * Examples showcasing the custom hooks API
  */
 
-/* eslint-disable @typescript-eslint/no-var-requires,@typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 const { registerReplaceHook } = require("@jazzer.js/hooking");
 const { reportFinding } = require("@jazzer.js/bug-detectors");

--- a/examples/bug-detectors/command-injection/custom-hooks.js
+++ b/examples/bug-detectors/command-injection/custom-hooks.js
@@ -16,8 +16,6 @@
  * Examples showcasing the custom hooks API
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 const { registerReplaceHook } = require("@jazzer.js/hooking");
 const { reportFinding } = require("@jazzer.js/bug-detectors");
 const { guideTowardsEquality } = require("@jazzer.js/fuzzer");
@@ -29,7 +27,7 @@ registerReplaceHook(
 	"execSync",
 	"child_process",
 	false,
-	(thisPtr, params, hookId, origFn) => {
+	(thisPtr, params, hookId) => {
 		if (params === undefined || params.length === 0) {
 			return;
 		}

--- a/examples/bug-detectors/command-injection/fuzz.js
+++ b/examples/bug-detectors/command-injection/fuzz.js
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { FuzzedDataProvider } = require("@jazzer.js/core");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const root = require("global-modules-path");
+
 module.exports.fuzz = function (data) {
 	const provider = new FuzzedDataProvider(data);
 	const str1 = provider.consumeString(provider.consumeIntegralInRange(1, 20));

--- a/examples/bug-detectors/path-traversal/fuzz.js
+++ b/examples/bug-detectors/path-traversal/fuzz.js
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const JSZip = require("jszip");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require("path");
 
 /**

--- a/examples/bug-detectors/path-traversal/fuzz.js
+++ b/examples/bug-detectors/path-traversal/fuzz.js
@@ -24,20 +24,17 @@ const path = require("path");
 module.exports.fuzz = function (data) {
 	// Parse the buffer into a JSZip object. The buffer might have been obtained from an http-request.
 	// See https://stuk.github.io/jszip/documentation/howto/read_zip.html for some examples.
-	return (
-		JSZip.loadAsync(data)
-			.then((zip) => {
-				for (const file in zip.files) {
-					// We might want to extract the file from the zip archive and write it to disk.
-					// The loadAsync function should have sanitized the path already.
-					// Here we only construct the absolute path and trigger the path traversal bug.
-					// This issue was fixed in jszip 3.8.0.
-					path.join(__dirname, file);
-				}
-			})
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
-			.catch(() => {
-				/* ignore broken zip files */
-			})
-	);
+	return JSZip.loadAsync(data)
+		.then((zip) => {
+			for (const file in zip.files) {
+				// We might want to extract the file from the zip archive and write it to disk.
+				// The loadAsync function should have sanitized the path already.
+				// Here we only construct the absolute path and trigger the path traversal bug.
+				// This issue was fixed in jszip 3.8.0.
+				path.join(__dirname, file);
+			}
+		})
+		.catch(() => {
+			/* ignore broken zip files */
+		});
 };

--- a/examples/custom-hooks/custom-hooks.js
+++ b/examples/custom-hooks/custom-hooks.js
@@ -1,5 +1,5 @@
 // noinspection JSUnusedLocalSymbols
-/* eslint-disable @typescript-eslint/no-var-requires,@typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 /*
  * Copyright 2022 Code Intelligence GmbH

--- a/examples/custom-hooks/custom-hooks.js
+++ b/examples/custom-hooks/custom-hooks.js
@@ -128,6 +128,7 @@ registerReplaceHook(
 	"JpegImage.jpegImage.constructor.prototype.parse.parse.NonExistingFunc",
 	"jpeg-js",
 	false,
-	// eslint-disable-next-line @typescript-eslint/no-empty-function
-	() => {},
+	() => {
+		/* empty */
+	},
 );

--- a/examples/custom-hooks/custom-hooks.js
+++ b/examples/custom-hooks/custom-hooks.js
@@ -1,6 +1,3 @@
-// noinspection JSUnusedLocalSymbols
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 /*
  * Copyright 2022 Code Intelligence GmbH
  *
@@ -32,7 +29,7 @@ registerReplaceHook(
 	"JpegImage.jpegImage.constructor.prototype.copyToImageData.copyToImageData",
 	"jpeg-js",
 	false,
-	(thisPtr, params, hookId, origFn) => {
+	(thisPtr, params) => {
 		if (params[0].data[0] === 0) {
 			// we are only interested in image frames in which data[0] equals zero
 			throw Error(
@@ -101,7 +98,7 @@ registerBeforeHook(
 	"JpegImage.jpegImage.constructor.prototype.parse.parse.readDataBlock",
 	"jpeg-js",
 	false,
-	(thisPtr, params, hookId) => {
+	() => {
 		console.log(
 			`[jpeg-js] [before] Called hooked function before calling resetMaxMemoryUsage()`,
 		);

--- a/examples/custom-hooks/fuzz.js
+++ b/examples/custom-hooks/fuzz.js
@@ -2,7 +2,6 @@
 // https://gitlab.com/gitlab-org/security-products/analyzers/fuzzers/jsfuzz/-/blob/34a694a8c73bfe0895c4e24784ba5b6dfe964b94/examples/jpeg/fuzz.js
 // The original code is available under the Apache License 2.0.
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const jpeg = require("jpeg-js");
 
 /**

--- a/examples/jest_integration/integration.fuzz.js
+++ b/examples/jest_integration/integration.fuzz.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint no-constant-condition: 0 */
-
 const target = require("./target.js");
 
 describe("My describe", () => {
@@ -55,7 +53,7 @@ describe("My describe", () => {
 	// finding and shut down the whole process with exit code 70.
 	it.skip.fuzz("Sync timeout", () => {
 		// noinspection InfiniteLoopJS
-		while (true) {
+		for (;;) {
 			// Ignore
 		}
 	});

--- a/examples/jest_integration/integration.fuzz.js
+++ b/examples/jest_integration/integration.fuzz.js
@@ -73,7 +73,6 @@ describe("My describe", () => {
 	// regression and fuzzing mode. libFuzzer shuts down the process after Jest
 	// received the error and displayed its result.
 	// Two parameters are required to execute the done callback branch.
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	it.skip.fuzz("Done callback timeout", (ignore, ignore2) => {
 		// don't call done
 	});

--- a/examples/jest_integration/integration.fuzz.js
+++ b/examples/jest_integration/integration.fuzz.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0, no-constant-condition: 0 */
+/* eslint no-constant-condition: 0 */
 
 const target = require("./target.js");
 

--- a/examples/jest_integration/integration.fuzz.js
+++ b/examples/jest_integration/integration.fuzz.js
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0, no-constant-condition: 0, @typescript-eslint/no-var-requires:0 */
+/* eslint no-undef: 0, no-constant-condition: 0 */
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const target = require("./target.js");
 
 describe("My describe", () => {

--- a/examples/jest_integration/integration.test.js
+++ b/examples/jest_integration/integration.test.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0 */
-
 describe("My describe", () => {
 	it("My normal Jest test", () => {
 		expect(1).toEqual(1);

--- a/examples/jest_integration/worker.fuzz.js
+++ b/examples/jest_integration/worker.fuzz.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0 */
-
 const target = require("./target");
 
 const startupTeardownCalls = [];

--- a/examples/jest_integration/worker.fuzz.js
+++ b/examples/jest_integration/worker.fuzz.js
@@ -16,7 +16,6 @@
 
 /* eslint no-undef: 0 */
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const target = require("./target");
 
 const startupTeardownCalls = [];

--- a/examples/jest_integration/worker.fuzz.js
+++ b/examples/jest_integration/worker.fuzz.js
@@ -56,7 +56,6 @@ describe("Hooks", () => {
 		let test = 0;
 		// Busy wait, do nothing
 		for (let i = 0; i < 1000; i++) {
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			test++;
 		}
 		addCallLog("My describe: afterEach");

--- a/examples/jest_integration/workerGoldenReference.test.js
+++ b/examples/jest_integration/workerGoldenReference.test.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0 */
-
 const startupTeardownCalls = [];
 
 function addCallLog(uniqueId) {

--- a/examples/jest_integration/workerGoldenReference.test.js
+++ b/examples/jest_integration/workerGoldenReference.test.js
@@ -58,7 +58,6 @@ describe("My describe", () => {
 		let test = 0;
 		// Busy wait, do nothing
 		for (let i = 0; i < 1000; i++) {
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			test++;
 		}
 		addCallLog("My describe: afterEach");

--- a/examples/jest_typescript_integration/integration.test.ts
+++ b/examples/jest_typescript_integration/integration.test.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0 */
-
 import * as target from "./target";
 
 describe("My describe", () => {

--- a/examples/jpeg/fuzz.js
+++ b/examples/jpeg/fuzz.js
@@ -2,7 +2,6 @@
 // https://gitlab.com/gitlab-org/security-products/analyzers/fuzzers/jsfuzz/-/blob/34a694a8c73bfe0895c4e24784ba5b6dfe964b94/examples/jpeg/fuzz.js
 // The original code is available under the Apache License 2.0.
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const jpeg = require("jpeg-js");
 
 /**

--- a/examples/jpeg_es6/fuzz.js
+++ b/examples/jpeg_es6/fuzz.js
@@ -2,7 +2,6 @@
 // https://gitlab.com/gitlab-org/security-products/analyzers/fuzzers/jsfuzz/-/blob/34a694a8c73bfe0895c4e24784ba5b6dfe964b94/examples/jpeg/fuzz.js
 // The original code is available under the Apache License 2.0.
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 import { decode } from "jpeg-js";
 
 /**

--- a/examples/spectral/spectral-example.js
+++ b/examples/spectral/spectral-example.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const parsers = require("@stoplight/spectral-parsers");
 
 /**

--- a/examples/xml/fuzz.js
+++ b/examples/xml/fuzz.js
@@ -2,7 +2,6 @@
 // https://gitlab.com/gitlab-org/security-products/analyzers/fuzzers/jsfuzz/-/blob/34a694a8c73bfe0895c4e24784ba5b6dfe964b94/examples/xml/fuzz.js
 // The original code is available under the Apache License 2.0.
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const xml2js = require("xml2js");
 
 /**

--- a/fuzztests/FuzzedDataProvider.fuzz.js
+++ b/fuzztests/FuzzedDataProvider.fuzz.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* eslint-disable no-undef, @typescript-eslint/no-var-requires */
+/* eslint-disable no-undef */
 
 const { FuzzedDataProvider, jazzer } = require("@jazzer.js/core");
 

--- a/fuzztests/FuzzedDataProvider.fuzz.js
+++ b/fuzztests/FuzzedDataProvider.fuzz.js
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-/* eslint-disable no-undef */
-
 const { FuzzedDataProvider, jazzer } = require("@jazzer.js/core");
 
 describe("FuzzedDataProvider", () => {
 	// In this fuzz test we try to guide the fuzzer to use as many functions on
 	// FuzzedDataProvider as possible, before invoking a terminating one
 	// like consumeRemainingXY. Strange combinations of functions could produce a
-	// one off error.
+	// one-off error.
 	it.fuzz(
 		"consumes the provided input",
 		(data) => {

--- a/fuzztests/core.fuzz.js
+++ b/fuzztests/core.fuzz.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* eslint-disable no-undef, @typescript-eslint/no-var-requires */
+/* eslint-disable no-undef */
 
 const { ensureFilepath } = require("@jazzer.js/core");
 

--- a/fuzztests/core.fuzz.js
+++ b/fuzztests/core.fuzz.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable no-undef */
-
 const { ensureFilepath } = require("@jazzer.js/core");
 
 const cwd = process.cwd();

--- a/fuzztests/fuzzer.fuzz.js
+++ b/fuzztests/fuzzer.fuzz.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* eslint-disable no-undef, @typescript-eslint/no-var-requires */
+/* eslint-disable no-undef */
 
 const { fuzzer } = require("@jazzer.js/fuzzer");
 const { FuzzedDataProvider } = require("@jazzer.js/core");

--- a/fuzztests/fuzzer.fuzz.js
+++ b/fuzztests/fuzzer.fuzz.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable no-undef */
-
 const { fuzzer } = require("@jazzer.js/fuzzer");
 const { FuzzedDataProvider } = require("@jazzer.js/core");
 

--- a/fuzztests/instrument.fuzz.js
+++ b/fuzztests/instrument.fuzz.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable no-undef */
-
 const { Instrumentor } = require("@jazzer.js/instrumentor");
 const { FuzzedDataProvider } = require("@jazzer.js/core");
 

--- a/fuzztests/instrument.fuzz.js
+++ b/fuzztests/instrument.fuzz.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* eslint-disable no-undef, @typescript-eslint/no-var-requires */
+/* eslint-disable no-undef */
 
 const { Instrumentor } = require("@jazzer.js/instrumentor");
 const { FuzzedDataProvider } = require("@jazzer.js/core");

--- a/fuzztests/runFuzzTests.js
+++ b/fuzztests/runFuzzTests.js
@@ -3,8 +3,6 @@
 // Helper script that searches for Jest fuzz tests in the current directory and
 // executes them in new processes using the found fuzz test names.
 
-/* eslint-disable @typescript-eslint/no-var-requires */
-
 const fs = require("fs/promises");
 const { spawn } = require("child_process");
 

--- a/packages/fuzzer/fuzzer.test.ts
+++ b/packages/fuzzer/fuzzer.test.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint no-empty-function: 0 */
 import { fuzzer } from "./fuzzer";
 
 describe("compare hooks", () => {

--- a/packages/hooking/hook.ts
+++ b/packages/hooking/hook.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* eslint @typescript-eslint/no-explicit-any: 0 */
+
 export interface TrackedHook {
 	target: string;
 	pkg: string;
@@ -143,7 +145,6 @@ export function logHooks(hooks: Hook[]) {
 
 export const hookTracker = new HookTracker();
 
-/*eslint @typescript-eslint/no-explicit-any: 0 */
 export enum HookType {
 	Before,
 	After,

--- a/packages/hooking/manager.test.ts
+++ b/packages/hooking/manager.test.ts
@@ -1,7 +1,6 @@
 import { hookManager } from "./manager";
 import { HookType } from "./hook";
 
-/* eslint @typescript-eslint/no-empty-function: 0 */
 /* eslint @typescript-eslint/ban-types: 0 */
 
 describe("Hooks manager", () => {
@@ -100,18 +99,18 @@ function registerHook(
 ) {
 	switch (hookType) {
 		case HookType.Before:
-			hookManager.registerHook(HookType.Before, target, pkg, isAsync, () => {});
+			hookManager.registerHook(HookType.Before, target, pkg, isAsync, () => {
+				/* empty */
+			});
 			break;
 		case HookType.Replace:
-			hookManager.registerHook(
-				HookType.Replace,
-				target,
-				pkg,
-				isAsync,
-				() => {},
-			);
+			hookManager.registerHook(HookType.Replace, target, pkg, isAsync, () => {
+				/* empty */
+			});
 			break;
 		case HookType.After:
-			hookManager.registerHook(HookType.After, target, pkg, isAsync, () => {});
+			hookManager.registerHook(HookType.After, target, pkg, isAsync, () => {
+				/* empty */
+			});
 	}
 }

--- a/packages/hooking/manager.test.ts
+++ b/packages/hooking/manager.test.ts
@@ -1,7 +1,21 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { hookManager } from "./manager";
 import { HookType } from "./hook";
-
-/* eslint @typescript-eslint/ban-types: 0 */
 
 describe("Hooks manager", () => {
 	describe("Matching hooks", () => {

--- a/packages/instrumentor/edgeIdStrategy.ts
+++ b/packages/instrumentor/edgeIdStrategy.ts
@@ -60,12 +60,10 @@ export class MemorySyncIdStrategy extends IncrementingEdgeIdStrategy {
 		super(0);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	startForSourceFile(filename: string): void {
 		// nothing to do here
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	commitIdCount(filename: string) {
 		// nothing to do here
 	}
@@ -240,12 +238,10 @@ export class ZeroEdgeIdStrategy implements EdgeIdStrategy {
 		return 0;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	startForSourceFile(filename: string): void {
 		// Nothing to do here
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	commitIdCount(filename: string): void {
 		// Nothing to do here
 	}

--- a/packages/instrumentor/instrument.test.ts
+++ b/packages/instrumentor/instrument.test.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint @typescript-eslint/ban-ts-comment:0 */
-
 import * as ts from "typescript";
 import { Instrumentor } from "./instrument";
 

--- a/packages/instrumentor/plugins/compareHooks.test.ts
+++ b/packages/instrumentor/plugins/compareHooks.test.ts
@@ -250,7 +250,6 @@ describe("compare hooks instrumentation", () => {
 // This is normally done by the jest environment. Here we replace every
 // API function with a jest mock, which can be configured in the test.
 function mockFuzzerApi() {
-	// eslint-disable-next-line @typescript-eslint/no-var-requires
 	const fuzzer = require("@jazzer.js/fuzzer").fuzzer;
 	jest.mock("@jazzer.js/fuzzer");
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -260,7 +259,6 @@ function mockFuzzerApi() {
 }
 
 function mockHelpers() {
-	// eslint-disable-next-line @typescript-eslint/no-var-requires
 	const helpers = require("./helpers");
 	jest.mock("./helpers");
 	return helpers;

--- a/packages/instrumentor/plugins/compareHooks.test.ts
+++ b/packages/instrumentor/plugins/compareHooks.test.ts
@@ -252,7 +252,6 @@ describe("compare hooks instrumentation", () => {
 function mockFuzzerApi() {
 	const fuzzer = require("@jazzer.js/fuzzer").fuzzer;
 	jest.mock("@jazzer.js/fuzzer");
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
 	global.Fuzzer = fuzzer;
 	return fuzzer;

--- a/packages/instrumentor/plugins/functionHooks.test.ts
+++ b/packages/instrumentor/plugins/functionHooks.test.ts
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint @typescript-eslint/no-unused-vars: 0 */
-/* eslint @typescript-eslint/no-empty-function: 0 */
-
 import { instrumentAndEvalWith } from "./testhelpers";
 import { functionHooks } from "./functionHooks";
 import * as hooking from "@jazzer.js/hooking";

--- a/packages/instrumentor/plugins/functionHooks.test.ts
+++ b/packages/instrumentor/plugins/functionHooks.test.ts
@@ -908,7 +908,6 @@ describe("function hooks instrumentation", () => {
 });
 
 function registerHookManagerGlobally() {
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
 	global.HookManager = hooking.hookManager;
 }

--- a/packages/instrumentor/plugins/functionHooks.test.ts
+++ b/packages/instrumentor/plugins/functionHooks.test.ts
@@ -562,8 +562,7 @@ describe("function hooks instrumentation", () => {
 			expectTrackedHooksUnknown(hookCallMap, 0);
 		});
 
-		//eslint-disable-next-line @typescript-eslint/no-explicit-any
-		it("one hook called after an async function", (): any => {
+		it("one hook called after an async function", () => {
 			hooking.hookManager.clearHooks();
 			hookTracker.clear();
 			const hookCallMap = registerAsyncFunctionHook(
@@ -619,8 +618,7 @@ describe("function hooks instrumentation", () => {
 			expectLogHooks(dbgMock, 1, "After", "foo");
 		});
 
-		//eslint-disable-next-line @typescript-eslint/no-explicit-any
-		it("two hooks called after an async function", (): any => {
+		it("two hooks called after an async function", () => {
 			hooking.hookManager.clearHooks();
 			hookTracker.clear();
 			const hookCallMap = registerAsyncFunctionHook(
@@ -832,8 +830,7 @@ describe("function hooks instrumentation", () => {
 			expectTrackedHooksUnknown(beforeHookCallMap, 0);
 			expectTrackedHooksUnknown(afterHookCallMap, 0);
 		});
-		//eslint-disable-next-line @typescript-eslint/no-explicit-any
-		it("one Before and ond After hook for an async function", (): any => {
+		it("one Before and ond After hook for an async function", () => {
 			hooking.hookManager.clearHooks();
 			hookTracker.clear();
 			const beforeHookCallMap = registerSyncFunctionHook(

--- a/packages/instrumentor/plugins/sourceCodeCoverage.test.ts
+++ b/packages/instrumentor/plugins/sourceCodeCoverage.test.ts
@@ -21,7 +21,6 @@ import { Instrumentor } from "../instrument";
 import * as libCoverage from "istanbul-lib-coverage";
 import { sourceCodeCoverage } from "./sourceCodeCoverage";
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const fuzzer = require("@jazzer.js/fuzzer").fuzzer;
 jest.mock("@jazzer.js/fuzzer");
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/instrumentor/plugins/sourceCodeCoverage.test.ts
+++ b/packages/instrumentor/plugins/sourceCodeCoverage.test.ts
@@ -23,7 +23,6 @@ import { sourceCodeCoverage } from "./sourceCodeCoverage";
 
 const fuzzer = require("@jazzer.js/fuzzer").fuzzer;
 jest.mock("@jazzer.js/fuzzer");
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 global.Fuzzer = fuzzer;
 

--- a/packages/jest-runner/fuzz.test.ts
+++ b/packages/jest-runner/fuzz.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 /*
  * Copyright 2022 Code Intelligence GmbH
  *

--- a/packages/jest-runner/fuzz.test.ts
+++ b/packages/jest-runner/fuzz.test.ts
@@ -151,7 +151,6 @@ describe("fuzz", () => {
 					runInRegressionMode(
 						"fuzz",
 						// Parameters needed to pass in done callback.
-						// eslint-disable-next-line @typescript-eslint/no-unused-vars
 						(ignored: Buffer, ignored2: (e?: Error) => void) => {
 							return new Promise(() => {
 								// promise is ignored due to done callback
@@ -172,7 +171,6 @@ describe("fuzz", () => {
 					withMockTest(() => {
 						runInRegressionMode(
 							"fuzz",
-							// eslint-disable-next-line @typescript-eslint/no-unused-vars
 							(ignored: Buffer, done: (e?: Error) => void) => {
 								done();
 								done();

--- a/packages/jest-runner/fuzz.ts
+++ b/packages/jest-runner/fuzz.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-
 import { Global } from "@jest/types";
 import {
 	FuzzTarget,

--- a/packages/jest-runner/index.ts
+++ b/packages/jest-runner/index.ts
@@ -48,7 +48,7 @@ class FuzzRunner extends CallbackTestRunner {
 		onStart: OnTestStart,
 		onResult: OnTestSuccess,
 		onFailure: OnTestFailure,
-		options: TestRunnerOptions, // eslint-disable-line @typescript-eslint/no-unused-vars
+		options: TestRunnerOptions,
 	): Promise<void> {
 		const config = loadConfig();
 		config.coverage = this.shouldCollectCoverage;

--- a/packages/jest-runner/worker.ts
+++ b/packages/jest-runner/worker.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-
 import { Test } from "jest-runner";
 import { Circus, Config } from "@jest/types";
 import { TestResult } from "@jest/test-result";

--- a/tests/FuzzedDataProvider/fuzz.js
+++ b/tests/FuzzedDataProvider/fuzz.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { FuzzedDataProvider } = require("@jazzer.js/core");
 
 /**

--- a/tests/bug-detectors/command-injection.test.js
+++ b/tests/bug-detectors/command-injection.test.js
@@ -15,14 +15,8 @@
  */
 
 /* eslint no-undef: 0 */
-const {
-	FuzzTestBuilder,
-	FuzzingExitCode,
-	// eslint-disable-next-line @typescript-eslint/no-var-requires
-} = require("../helpers.js");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { FuzzTestBuilder, FuzzingExitCode } = require("../helpers.js");
 const path = require("path");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const fs = require("fs");
 
 describe("Command injection", () => {

--- a/tests/bug-detectors/command-injection.test.js
+++ b/tests/bug-detectors/command-injection.test.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0 */
 const { FuzzTestBuilder, FuzzingExitCode } = require("../helpers.js");
 const path = require("path");
 const fs = require("fs");

--- a/tests/bug-detectors/command-injection/fuzz.js
+++ b/tests/bug-detectors/command-injection/fuzz.js
@@ -23,22 +23,18 @@ const evilCommand = "jaz_zer";
 const friendlyCommand =
 	(process.platform === "win32" ? "copy NUL " : "touch ") + friendlyFile;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 module.exports.execEVIL = async function (data) {
 	child_process.exec(evilCommand);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 module.exports.execFRIENDLY = async function (data) {
 	child_process.exec(friendlyCommand);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 module.exports.execFileEVIL = async function (data) {
 	child_process.execFile(evilCommand);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 module.exports.execFileFRIENDLY = async function (data) {
 	const command = process.platform === "win32" ? "copy" : "touch";
 	const args =
@@ -47,12 +43,10 @@ module.exports.execFileFRIENDLY = async function (data) {
 	await execFile(command, args, { shell: true });
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 module.exports.execFileSyncEVIL = function (data) {
 	child_process.execFileSync(evilCommand);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 module.exports.execFileSyncFRIENDLY = function (data) {
 	const command = process.platform === "win32" ? "copy" : "touch";
 	const args =
@@ -61,12 +55,10 @@ module.exports.execFileSyncFRIENDLY = function (data) {
 	child_process.execFileSync(command, args, options);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 module.exports.spawnEVIL = async function (data) {
 	child_process.spawn(evilCommand);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 module.exports.spawnFRIENDLY = async function (data) {
 	const command = process.platform === "win32" ? "copy" : "touch";
 	const args =
@@ -82,12 +74,10 @@ module.exports.spawnFRIENDLY = async function (data) {
 	});
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 module.exports.spawnSyncEVIL = function (data) {
 	child_process.spawnSync(evilCommand);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 module.exports.spawnSyncFRIENDLY = function (data) {
 	const command = process.platform === "win32" ? "copy" : "touch";
 	const args =
@@ -95,12 +85,10 @@ module.exports.spawnSyncFRIENDLY = function (data) {
 	child_process.spawnSync(command, args, { shell: true });
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 module.exports.forkEVIL = function (data) {
 	child_process.fork(evilCommand);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 module.exports.forkFRIENDLY = function (data) {
 	child_process.fork("makeFRIENDLY.js");
 };

--- a/tests/bug-detectors/command-injection/fuzz.js
+++ b/tests/bug-detectors/command-injection/fuzz.js
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const child_process = require("child_process");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { promisify } = require("util");
 
 const friendlyFile = "FRIENDLY";

--- a/tests/bug-detectors/command-injection/makeFRIENDLY.js
+++ b/tests/bug-detectors/command-injection/makeFRIENDLY.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const fs = require("fs");
 
 fs.writeFileSync("FRIENDLY", "");

--- a/tests/bug-detectors/general.test.js
+++ b/tests/bug-detectors/general.test.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0 */
 const {
 	FuzzTestBuilder,
 	FuzzingExitCode,

--- a/tests/bug-detectors/general.test.js
+++ b/tests/bug-detectors/general.test.js
@@ -19,11 +19,8 @@ const {
 	FuzzTestBuilder,
 	FuzzingExitCode,
 	JestRegressionExitCode,
-	// eslint-disable-next-line @typescript-eslint/no-var-requires
 } = require("../helpers.js");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require("path");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const fs = require("fs");
 
 describe("General tests", () => {

--- a/tests/bug-detectors/general/fuzz.js
+++ b/tests/bug-detectors/general/fuzz.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
 
 const child_process = require("child_process");

--- a/tests/bug-detectors/general/fuzz.js
+++ b/tests/bug-detectors/general/fuzz.js
@@ -15,7 +15,6 @@
  */
 
 /* eslint no-undef: 0 */
-/* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
 

--- a/tests/bug-detectors/general/fuzz.js
+++ b/tests/bug-detectors/general/fuzz.js
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-empty-function */
-
 const child_process = require("child_process");
-const path = require("path");
 const fs = require("fs");
 const assert = require("assert");
 const { platform } = require("os");

--- a/tests/bug-detectors/general/fuzz.js
+++ b/tests/bug-detectors/general/fuzz.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0 */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
 

--- a/tests/bug-detectors/general/tests.fuzz.js
+++ b/tests/bug-detectors/general/tests.fuzz.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-empty-function */
-
 const child_process = require("child_process");
 const assert = require("assert");
 
@@ -69,7 +67,7 @@ function test(data) {
 	try {
 		child_process.execSync(data);
 	} catch (e) {
-		// eslint-disable-line no-empty
+		// Ignored
 	}
 }
 

--- a/tests/bug-detectors/general/tests.fuzz.js
+++ b/tests/bug-detectors/general/tests.fuzz.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
 
 const child_process = require("child_process");
@@ -81,7 +80,6 @@ function test(data) {
 function makeFuzzFunctionWithInput(n, input) {
 	assert(n > 0);
 	let i = n;
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	return function (data) {
 		i--;
 		if (i === 0) {

--- a/tests/bug-detectors/general/tests.fuzz.js
+++ b/tests/bug-detectors/general/tests.fuzz.js
@@ -15,7 +15,6 @@
  */
 
 /* eslint no-undef: 0 */
-/* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
 

--- a/tests/bug-detectors/general/tests.fuzz.js
+++ b/tests/bug-detectors/general/tests.fuzz.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0 */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
 

--- a/tests/bug-detectors/path-traversal.test.js
+++ b/tests/bug-detectors/path-traversal.test.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0 */
 const { FuzzTestBuilder, FuzzingExitCode } = require("../helpers.js");
 const path = require("path");
 const fs = require("fs");

--- a/tests/bug-detectors/path-traversal.test.js
+++ b/tests/bug-detectors/path-traversal.test.js
@@ -15,14 +15,8 @@
  */
 
 /* eslint no-undef: 0 */
-const {
-	FuzzTestBuilder,
-	FuzzingExitCode,
-	// eslint-disable-next-line @typescript-eslint/no-var-requires
-} = require("../helpers.js");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { FuzzTestBuilder, FuzzingExitCode } = require("../helpers.js");
 const path = require("path");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const fs = require("fs");
 
 describe("Path Traversal", () => {

--- a/tests/bug-detectors/path-traversal/fuzz.js
+++ b/tests/bug-detectors/path-traversal/fuzz.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0 */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
 
@@ -22,7 +21,7 @@ const fs = require("fs");
 const fsp = require("fs").promises;
 const path = require("path");
 
-const { makeFnCalledOnce } = require("../../helpers");
+const { makeFnCalledOnce, callWithTimeout } = require("../../helpers");
 
 const evil_path = "../../jaz_zer/";
 const safe_path = "../../safe_path/";

--- a/tests/bug-detectors/path-traversal/fuzz.js
+++ b/tests/bug-detectors/path-traversal/fuzz.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
 
 const fs = require("fs");
@@ -38,7 +37,7 @@ module.exports.PathTraversalFsOpenEvilSync = makeFnCalledOnce((data) => {
 });
 
 module.exports.PathTraversalFsOpenEvilAsync = makeFnCalledOnce(async (data) => {
-	fs.open(evil_path, "r", (err, f) => {});
+	fs.open(evil_path, "r", () => {});
 });
 
 module.exports.PathTraversalFsMkdirEvilSync = makeFnCalledOnce((data) => {

--- a/tests/bug-detectors/path-traversal/fuzz.js
+++ b/tests/bug-detectors/path-traversal/fuzz.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-empty-function */
-
 const fs = require("fs");
 const fsp = require("fs").promises;
 const path = require("path");
@@ -37,7 +35,9 @@ module.exports.PathTraversalFsOpenEvilSync = makeFnCalledOnce((data) => {
 });
 
 module.exports.PathTraversalFsOpenEvilAsync = makeFnCalledOnce(async (data) => {
-	fs.open(evil_path, "r", () => {});
+	fs.open(evil_path, "r", () => {
+		/* empty */
+	});
 });
 
 module.exports.PathTraversalFsMkdirEvilSync = makeFnCalledOnce((data) => {
@@ -50,13 +50,17 @@ module.exports.PathTraversalFsMkdirSafeSync = makeFnCalledOnce((data) => {
 
 module.exports.PathTraversalFsMkdirEvilAsync = makeFnCalledOnce(
 	async (data) => {
-		fs.mkdir(evil_path, () => {});
+		fs.mkdir(evil_path, () => {
+			/* empty */
+		});
 	},
 );
 
 module.exports.PathTraversalFsMkdirSafeAsync = makeFnCalledOnce(
 	async (data) => {
-		fs.mkdir(safe_path, () => {});
+		fs.mkdir(safe_path, () => {
+			/* empty */
+		});
 	},
 );
 

--- a/tests/bug-detectors/path-traversal/fuzz.js
+++ b/tests/bug-detectors/path-traversal/fuzz.js
@@ -15,7 +15,6 @@
  */
 
 /* eslint no-undef: 0 */
-/* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
 

--- a/tests/code_coverage/coverage.test.js
+++ b/tests/code_coverage/coverage.test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0, @typescript-eslint/no-var-requires: 0 */
+/* eslint no-undef: 0 */
 const fs = require("fs");
 const path = require("path");
 const { spawnSync } = require("child_process");

--- a/tests/code_coverage/coverage.test.js
+++ b/tests/code_coverage/coverage.test.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0 */
 const fs = require("fs");
 const path = require("path");
 const { spawnSync } = require("child_process");

--- a/tests/code_coverage/sample_fuzz_test/codeCoverage.fuzz.js
+++ b/tests/code_coverage/sample_fuzz_test/codeCoverage.fuzz.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0, no-constant-condition: 0 */
-
 const target = require("./fuzz.js");
 
 describe("My describe", () => {

--- a/tests/code_coverage/sample_fuzz_test/codeCoverage.fuzz.js
+++ b/tests/code_coverage/sample_fuzz_test/codeCoverage.fuzz.js
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0, no-constant-condition: 0, @typescript-eslint/no-var-requires:0 */
+/* eslint no-undef: 0, no-constant-condition: 0 */
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const target = require("./fuzz.js");
 
 describe("My describe", () => {

--- a/tests/code_coverage/sample_fuzz_test/custom-hooks.js
+++ b/tests/code_coverage/sample_fuzz_test/custom-hooks.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { registerReplaceHook } = require("@jazzer.js/hooking");
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/tests/code_coverage/sample_fuzz_test/custom-hooks.js
+++ b/tests/code_coverage/sample_fuzz_test/custom-hooks.js
@@ -1,6 +1,5 @@
 const { registerReplaceHook } = require("@jazzer.js/hooking");
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-registerReplaceHook("foo", "lib", false, (thisPtr, params, hookId, origFn) => {
+registerReplaceHook("foo", "lib", false, () => {
 	console.log("CUSTOM HOOKS CALLED!");
 });

--- a/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib+codeCoverage-fuzz.json
+++ b/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib+codeCoverage-fuzz.json
@@ -2,46 +2,46 @@
 	"codeCoverage.fuzz.js": {
 		"statementMap": {
 			"0": {
-				"start": { "line": 19, "column": 15 },
-				"end": { "line": 19, "column": 35 }
+				"start": { "line": 17, "column": 15 },
+				"end": { "line": 17, "column": 35 }
 			},
 			"1": {
-				"start": { "line": 21, "column": 0 },
-				"end": { "line": 25, "column": 3 }
+				"start": { "line": 19, "column": 0 },
+				"end": { "line": 23, "column": 3 }
 			},
 			"2": {
-				"start": { "line": 22, "column": 1 },
-				"end": { "line": 24, "column": 4 }
+				"start": { "line": 20, "column": 1 },
+				"end": { "line": 22, "column": 4 }
 			},
 			"3": {
-				"start": { "line": 23, "column": 2 },
-				"end": { "line": 23, "column": 20 }
+				"start": { "line": 21, "column": 2 },
+				"end": { "line": 21, "column": 20 }
 			}
 		},
 		"fnMap": {
 			"0": {
 				"name": "(anonymous_0)",
 				"decl": {
-					"start": { "line": 21, "column": 24 },
-					"end": { "line": 21, "column": 25 }
+					"start": { "line": 19, "column": 24 },
+					"end": { "line": 19, "column": 25 }
 				},
 				"loc": {
-					"start": { "line": 21, "column": 30 },
-					"end": { "line": 25, "column": 1 }
+					"start": { "line": 19, "column": 30 },
+					"end": { "line": 23, "column": 1 }
 				},
-				"line": 21
+				"line": 19
 			},
 			"1": {
 				"name": "(anonymous_1)",
 				"decl": {
-					"start": { "line": 22, "column": 25 },
-					"end": { "line": 22, "column": 26 }
+					"start": { "line": 20, "column": 25 },
+					"end": { "line": 20, "column": 26 }
 				},
 				"loc": {
-					"start": { "line": 22, "column": 35 },
-					"end": { "line": 24, "column": 2 }
+					"start": { "line": 20, "column": 35 },
+					"end": { "line": 22, "column": 2 }
 				},
-				"line": 22
+				"line": 20
 			}
 		},
 		"branchMap": {},

--- a/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib+codeCoverage-fuzz.json
+++ b/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib+codeCoverage-fuzz.json
@@ -2,46 +2,46 @@
 	"codeCoverage.fuzz.js": {
 		"statementMap": {
 			"0": {
-				"start": { "line": 20, "column": 15 },
-				"end": { "line": 20, "column": 35 }
+				"start": { "line": 19, "column": 15 },
+				"end": { "line": 19, "column": 35 }
 			},
 			"1": {
-				"start": { "line": 22, "column": 0 },
-				"end": { "line": 26, "column": 3 }
+				"start": { "line": 21, "column": 0 },
+				"end": { "line": 25, "column": 3 }
 			},
 			"2": {
-				"start": { "line": 23, "column": 1 },
-				"end": { "line": 25, "column": 4 }
+				"start": { "line": 22, "column": 1 },
+				"end": { "line": 24, "column": 4 }
 			},
 			"3": {
-				"start": { "line": 24, "column": 2 },
-				"end": { "line": 24, "column": 20 }
+				"start": { "line": 23, "column": 2 },
+				"end": { "line": 23, "column": 20 }
 			}
 		},
 		"fnMap": {
 			"0": {
 				"name": "(anonymous_0)",
 				"decl": {
-					"start": { "line": 22, "column": 24 },
-					"end": { "line": 22, "column": 25 }
+					"start": { "line": 21, "column": 24 },
+					"end": { "line": 21, "column": 25 }
 				},
 				"loc": {
-					"start": { "line": 22, "column": 30 },
-					"end": { "line": 26, "column": 1 }
+					"start": { "line": 21, "column": 30 },
+					"end": { "line": 25, "column": 1 }
 				},
-				"line": 22
+				"line": 21
 			},
 			"1": {
 				"name": "(anonymous_1)",
 				"decl": {
-					"start": { "line": 23, "column": 25 },
-					"end": { "line": 23, "column": 26 }
+					"start": { "line": 22, "column": 25 },
+					"end": { "line": 22, "column": 26 }
 				},
 				"loc": {
-					"start": { "line": 23, "column": 35 },
-					"end": { "line": 25, "column": 2 }
+					"start": { "line": 22, "column": 35 },
+					"end": { "line": 24, "column": 2 }
 				},
-				"line": 23
+				"line": 22
 			}
 		},
 		"branchMap": {},
@@ -54,59 +54,59 @@
 	"fuzz.js": {
 		"statementMap": {
 			"0": {
-				"start": { "line": 18, "column": 12 },
-				"end": { "line": 18, "column": 28 }
+				"start": { "line": 17, "column": 12 },
+				"end": { "line": 17, "column": 28 }
 			},
 			"1": {
-				"start": { "line": 23, "column": 0 },
-				"end": { "line": 29, "column": 2 }
+				"start": { "line": 22, "column": 0 },
+				"end": { "line": 28, "column": 2 }
 			},
 			"2": {
-				"start": { "line": 24, "column": 1 },
-				"end": { "line": 24, "column": 41 }
+				"start": { "line": 23, "column": 1 },
+				"end": { "line": 23, "column": 41 }
 			},
 			"3": {
-				"start": { "line": 25, "column": 1 },
-				"end": { "line": 27, "column": 2 }
+				"start": { "line": 24, "column": 1 },
+				"end": { "line": 26, "column": 2 }
 			},
 			"4": {
-				"start": { "line": 26, "column": 2 },
-				"end": { "line": 26, "column": 9 }
+				"start": { "line": 25, "column": 2 },
+				"end": { "line": 25, "column": 9 }
 			},
 			"5": {
-				"start": { "line": 28, "column": 1 },
-				"end": { "line": 28, "column": 18 }
+				"start": { "line": 27, "column": 1 },
+				"end": { "line": 27, "column": 18 }
 			}
 		},
 		"fnMap": {
 			"0": {
 				"name": "(anonymous_0)",
 				"decl": {
-					"start": { "line": 23, "column": 22 },
-					"end": { "line": 23, "column": 23 }
+					"start": { "line": 22, "column": 22 },
+					"end": { "line": 22, "column": 23 }
 				},
 				"loc": {
-					"start": { "line": 23, "column": 38 },
-					"end": { "line": 29, "column": 1 }
+					"start": { "line": 22, "column": 38 },
+					"end": { "line": 28, "column": 1 }
 				},
-				"line": 23
+				"line": 22
 			}
 		},
 		"branchMap": {
 			"0": {
 				"loc": {
-					"start": { "line": 25, "column": 1 },
-					"end": { "line": 27, "column": 2 }
+					"start": { "line": 24, "column": 1 },
+					"end": { "line": 26, "column": 2 }
 				},
 				"type": "if",
 				"locations": [
 					{
-						"start": { "line": 25, "column": 1 },
-						"end": { "line": 27, "column": 2 }
+						"start": { "line": 24, "column": 1 },
+						"end": { "line": 26, "column": 2 }
 					},
 					{ "start": {}, "end": {} }
 				],
-				"line": 25
+				"line": 24
 			}
 		},
 		"s": { "0": 1, "1": 1, "2": 2, "3": 2, "4": 1, "5": 1 },

--- a/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib+customHooks.json
+++ b/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib+customHooks.json
@@ -6,26 +6,26 @@
 				"end": { "line": 1, "column": 61 }
 			},
 			"1": {
-				"start": { "line": 4, "column": 0 },
-				"end": { "line": 6, "column": 3 }
+				"start": { "line": 3, "column": 0 },
+				"end": { "line": 5, "column": 3 }
 			},
 			"2": {
-				"start": { "line": 5, "column": 1 },
-				"end": { "line": 5, "column": 37 }
+				"start": { "line": 4, "column": 1 },
+				"end": { "line": 4, "column": 37 }
 			}
 		},
 		"fnMap": {
 			"0": {
 				"name": "(anonymous_0)",
 				"decl": {
-					"start": { "line": 4, "column": 41 },
-					"end": { "line": 4, "column": 42 }
+					"start": { "line": 3, "column": 41 },
+					"end": { "line": 3, "column": 42 }
 				},
 				"loc": {
-					"start": { "line": 4, "column": 78 },
-					"end": { "line": 6, "column": 1 }
+					"start": { "line": 3, "column": 47 },
+					"end": { "line": 5, "column": 1 }
 				},
-				"line": 4
+				"line": 3
 			}
 		},
 		"branchMap": {},

--- a/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib+customHooks.json
+++ b/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib+customHooks.json
@@ -2,30 +2,30 @@
 	"custom-hooks.js": {
 		"statementMap": {
 			"0": {
-				"start": { "line": 2, "column": 32 },
-				"end": { "line": 2, "column": 61 }
+				"start": { "line": 1, "column": 32 },
+				"end": { "line": 1, "column": 61 }
 			},
 			"1": {
-				"start": { "line": 5, "column": 0 },
-				"end": { "line": 7, "column": 3 }
+				"start": { "line": 4, "column": 0 },
+				"end": { "line": 6, "column": 3 }
 			},
 			"2": {
-				"start": { "line": 6, "column": 1 },
-				"end": { "line": 6, "column": 37 }
+				"start": { "line": 5, "column": 1 },
+				"end": { "line": 5, "column": 37 }
 			}
 		},
 		"fnMap": {
 			"0": {
 				"name": "(anonymous_0)",
 				"decl": {
-					"start": { "line": 5, "column": 41 },
-					"end": { "line": 5, "column": 42 }
+					"start": { "line": 4, "column": 41 },
+					"end": { "line": 4, "column": 42 }
 				},
 				"loc": {
-					"start": { "line": 5, "column": 78 },
-					"end": { "line": 7, "column": 1 }
+					"start": { "line": 4, "column": 78 },
+					"end": { "line": 6, "column": 1 }
 				},
-				"line": 5
+				"line": 4
 			}
 		},
 		"branchMap": {},
@@ -38,59 +38,59 @@
 	"fuzz.js": {
 		"statementMap": {
 			"0": {
-				"start": { "line": 18, "column": 12 },
-				"end": { "line": 18, "column": 28 }
+				"start": { "line": 17, "column": 12 },
+				"end": { "line": 17, "column": 28 }
 			},
 			"1": {
-				"start": { "line": 23, "column": 0 },
-				"end": { "line": 29, "column": 2 }
+				"start": { "line": 22, "column": 0 },
+				"end": { "line": 28, "column": 2 }
 			},
 			"2": {
-				"start": { "line": 24, "column": 1 },
-				"end": { "line": 24, "column": 41 }
+				"start": { "line": 23, "column": 1 },
+				"end": { "line": 23, "column": 41 }
 			},
 			"3": {
-				"start": { "line": 25, "column": 1 },
-				"end": { "line": 27, "column": 2 }
+				"start": { "line": 24, "column": 1 },
+				"end": { "line": 26, "column": 2 }
 			},
 			"4": {
-				"start": { "line": 26, "column": 2 },
-				"end": { "line": 26, "column": 9 }
+				"start": { "line": 25, "column": 2 },
+				"end": { "line": 25, "column": 9 }
 			},
 			"5": {
-				"start": { "line": 28, "column": 1 },
-				"end": { "line": 28, "column": 18 }
+				"start": { "line": 27, "column": 1 },
+				"end": { "line": 27, "column": 18 }
 			}
 		},
 		"fnMap": {
 			"0": {
 				"name": "(anonymous_0)",
 				"decl": {
-					"start": { "line": 23, "column": 22 },
-					"end": { "line": 23, "column": 23 }
+					"start": { "line": 22, "column": 22 },
+					"end": { "line": 22, "column": 23 }
 				},
 				"loc": {
-					"start": { "line": 23, "column": 38 },
-					"end": { "line": 29, "column": 1 }
+					"start": { "line": 22, "column": 38 },
+					"end": { "line": 28, "column": 1 }
 				},
-				"line": 23
+				"line": 22
 			}
 		},
 		"branchMap": {
 			"0": {
 				"loc": {
-					"start": { "line": 25, "column": 1 },
-					"end": { "line": 27, "column": 2 }
+					"start": { "line": 24, "column": 1 },
+					"end": { "line": 26, "column": 2 }
 				},
 				"type": "if",
 				"locations": [
 					{
-						"start": { "line": 25, "column": 1 },
-						"end": { "line": 27, "column": 2 }
+						"start": { "line": 24, "column": 1 },
+						"end": { "line": 26, "column": 2 }
 					},
 					{ "start": {}, "end": {} }
 				],
-				"line": 25
+				"line": 24
 			}
 		},
 		"s": { "0": 1, "1": 1, "2": 3, "3": 3, "4": 2, "5": 1 },

--- a/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib+otherCodeCoverage-fuzz.json
+++ b/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib+otherCodeCoverage-fuzz.json
@@ -63,59 +63,59 @@
 	"fuzz.js": {
 		"statementMap": {
 			"0": {
-				"start": { "line": 18, "column": 12 },
-				"end": { "line": 18, "column": 28 }
+				"start": { "line": 17, "column": 12 },
+				"end": { "line": 17, "column": 28 }
 			},
 			"1": {
-				"start": { "line": 23, "column": 0 },
-				"end": { "line": 29, "column": 2 }
+				"start": { "line": 22, "column": 0 },
+				"end": { "line": 28, "column": 2 }
 			},
 			"2": {
-				"start": { "line": 24, "column": 1 },
-				"end": { "line": 24, "column": 41 }
+				"start": { "line": 23, "column": 1 },
+				"end": { "line": 23, "column": 41 }
 			},
 			"3": {
-				"start": { "line": 25, "column": 1 },
-				"end": { "line": 27, "column": 2 }
+				"start": { "line": 24, "column": 1 },
+				"end": { "line": 26, "column": 2 }
 			},
 			"4": {
-				"start": { "line": 26, "column": 2 },
-				"end": { "line": 26, "column": 9 }
+				"start": { "line": 25, "column": 2 },
+				"end": { "line": 25, "column": 9 }
 			},
 			"5": {
-				"start": { "line": 28, "column": 1 },
-				"end": { "line": 28, "column": 18 }
+				"start": { "line": 27, "column": 1 },
+				"end": { "line": 27, "column": 18 }
 			}
 		},
 		"fnMap": {
 			"0": {
 				"name": "(anonymous_0)",
 				"decl": {
-					"start": { "line": 23, "column": 22 },
-					"end": { "line": 23, "column": 23 }
+					"start": { "line": 22, "column": 22 },
+					"end": { "line": 22, "column": 23 }
 				},
 				"loc": {
-					"start": { "line": 23, "column": 38 },
-					"end": { "line": 29, "column": 1 }
+					"start": { "line": 22, "column": 38 },
+					"end": { "line": 28, "column": 1 }
 				},
-				"line": 23
+				"line": 22
 			}
 		},
 		"branchMap": {
 			"0": {
 				"loc": {
-					"start": { "line": 25, "column": 1 },
-					"end": { "line": 27, "column": 2 }
+					"start": { "line": 24, "column": 1 },
+					"end": { "line": 26, "column": 2 }
 				},
 				"type": "if",
 				"locations": [
 					{
-						"start": { "line": 25, "column": 1 },
-						"end": { "line": 27, "column": 2 }
+						"start": { "line": 24, "column": 1 },
+						"end": { "line": 26, "column": 2 }
 					},
 					{ "start": {}, "end": {} }
 				],
-				"line": 25
+				"line": 24
 			}
 		},
 		"s": { "0": 1, "1": 1, "2": 2, "3": 2, "4": 1, "5": 1 },

--- a/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib.json
+++ b/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib.json
@@ -2,59 +2,59 @@
 	"fuzz.js": {
 		"statementMap": {
 			"0": {
-				"start": { "line": 18, "column": 12 },
-				"end": { "line": 18, "column": 28 }
+				"start": { "line": 17, "column": 12 },
+				"end": { "line": 17, "column": 28 }
 			},
 			"1": {
-				"start": { "line": 23, "column": 0 },
-				"end": { "line": 29, "column": 2 }
+				"start": { "line": 22, "column": 0 },
+				"end": { "line": 28, "column": 2 }
 			},
 			"2": {
-				"start": { "line": 24, "column": 1 },
-				"end": { "line": 24, "column": 41 }
+				"start": { "line": 23, "column": 1 },
+				"end": { "line": 23, "column": 41 }
 			},
 			"3": {
-				"start": { "line": 25, "column": 1 },
-				"end": { "line": 27, "column": 2 }
+				"start": { "line": 24, "column": 1 },
+				"end": { "line": 26, "column": 2 }
 			},
 			"4": {
-				"start": { "line": 26, "column": 2 },
-				"end": { "line": 26, "column": 9 }
+				"start": { "line": 25, "column": 2 },
+				"end": { "line": 25, "column": 9 }
 			},
 			"5": {
-				"start": { "line": 28, "column": 1 },
-				"end": { "line": 28, "column": 18 }
+				"start": { "line": 27, "column": 1 },
+				"end": { "line": 27, "column": 18 }
 			}
 		},
 		"fnMap": {
 			"0": {
 				"name": "(anonymous_0)",
 				"decl": {
-					"start": { "line": 23, "column": 22 },
-					"end": { "line": 23, "column": 23 }
+					"start": { "line": 22, "column": 22 },
+					"end": { "line": 22, "column": 23 }
 				},
 				"loc": {
-					"start": { "line": 23, "column": 38 },
-					"end": { "line": 29, "column": 1 }
+					"start": { "line": 22, "column": 38 },
+					"end": { "line": 28, "column": 1 }
 				},
-				"line": 23
+				"line": 22
 			}
 		},
 		"branchMap": {
 			"0": {
 				"loc": {
-					"start": { "line": 25, "column": 1 },
-					"end": { "line": 27, "column": 2 }
+					"start": { "line": 24, "column": 1 },
+					"end": { "line": 26, "column": 2 }
 				},
 				"type": "if",
 				"locations": [
 					{
-						"start": { "line": 25, "column": 1 },
-						"end": { "line": 27, "column": 2 }
+						"start": { "line": 24, "column": 1 },
+						"end": { "line": 26, "column": 2 }
 					},
 					{ "start": {}, "end": {} }
 				],
-				"line": 25
+				"line": 24
 			}
 		},
 		"s": { "0": 1, "1": 1, "2": 3, "3": 3, "4": 2, "5": 1 },

--- a/tests/code_coverage/sample_fuzz_test/fuzz.js
+++ b/tests/code_coverage/sample_fuzz_test/fuzz.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const lib = require("./lib");
 
 /**

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { spawnSync } = require("child_process");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const fs = require("fs");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require("path");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+
 const assert = require("assert");
 
 // This is used to distinguish an error thrown during fuzzing from other errors,

--- a/tests/return_values/asyncRunnerAsyncReturns/fuzz.js
+++ b/tests/return_values/asyncRunnerAsyncReturns/fuzz.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-var-requires */
 const code = require("../exampleCode/code");
 
 let syncCtr = 0;

--- a/tests/return_values/asyncRunnerMixedReturns/fuzz.js
+++ b/tests/return_values/asyncRunnerMixedReturns/fuzz.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-var-requires */
 const code = require("../exampleCode/code");
 
 let syncCtr = 0;

--- a/tests/return_values/asyncRunnerSyncReturns/fuzz.js
+++ b/tests/return_values/asyncRunnerSyncReturns/fuzz.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-var-requires */
 const code = require("../exampleCode/code");
 
 let syncCtr = 0;

--- a/tests/return_values/return_values.test.js
+++ b/tests/return_values/return_values.test.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0 */
 const { spawnSync } = require("child_process");
 const path = require("path");
 const SyncInfo =

--- a/tests/return_values/return_values.test.js
+++ b/tests/return_values/return_values.test.js
@@ -15,9 +15,7 @@
  */
 
 /* eslint no-undef: 0 */
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { spawnSync } = require("child_process");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require("path");
 const SyncInfo =
 	"Exclusively observed synchronous return values from fuzzed function. Fuzzing in synchronous mode seems benefical!";

--- a/tests/return_values/return_values.test.js
+++ b/tests/return_values/return_values.test.js
@@ -68,7 +68,6 @@ function executeFuzzTest(sync, verbose, dir) {
 	// Specify mode
 	if (sync) options.push("--sync");
 	options.push("--");
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const process = spawnSync("npx", options, {
 		stdio: "pipe",
 		cwd: dir,

--- a/tests/return_values/syncRunnerAsyncReturns/fuzz.js
+++ b/tests/return_values/syncRunnerAsyncReturns/fuzz.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-var-requires */
 const code = require("../exampleCode/code");
 
 let syncCtr = 0;

--- a/tests/return_values/syncRunnerMixedReturns/fuzz.js
+++ b/tests/return_values/syncRunnerMixedReturns/fuzz.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-var-requires */
 const code = require("../exampleCode/code");
 
 let syncCtr = 0;

--- a/tests/return_values/syncRunnerSyncReturns/fuzz.js
+++ b/tests/return_values/syncRunnerSyncReturns/fuzz.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-var-requires */
 const code = require("../exampleCode/code");
 
 let syncCtr = 0;

--- a/tests/signal_handlers/SIGINT/fuzz.js
+++ b/tests/signal_handlers/SIGINT/fuzz.js
@@ -16,7 +16,6 @@
 
 let i = 0;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 module.exports.SIGINT_SYNC = (data) => {
 	if (i === 1000) {
 		console.log("kill with SIGINT");
@@ -28,7 +27,6 @@ module.exports.SIGINT_SYNC = (data) => {
 	i++;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 module.exports.SIGINT_ASYNC = (data) => {
 	// Raising SIGINT in async mode does not stop the fuzzer directly,
 	// as the event is handled asynchronously in the event loop.

--- a/tests/signal_handlers/SIGINT/tests.fuzz.js
+++ b/tests/signal_handlers/SIGINT/tests.fuzz.js
@@ -15,7 +15,6 @@
  */
 
 /* eslint no-undef: 0 */
-/* eslint-disable @typescript-eslint/no-var-requires */
 
 const { SIGINT_SYNC, SIGINT_ASYNC } = require("./fuzz.js");
 

--- a/tests/signal_handlers/SIGINT/tests.fuzz.js
+++ b/tests/signal_handlers/SIGINT/tests.fuzz.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0 */
-
 const { SIGINT_SYNC, SIGINT_ASYNC } = require("./fuzz.js");
 
 describe("Jest", () => {

--- a/tests/signal_handlers/signal_handlers.test.js
+++ b/tests/signal_handlers/signal_handlers.test.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint no-undef: 0 */
 const { FuzzTestBuilder, describeSkipOnPlatform } = require("../helpers.js");
 const path = require("path");
 

--- a/tests/signal_handlers/signal_handlers.test.js
+++ b/tests/signal_handlers/signal_handlers.test.js
@@ -15,12 +15,7 @@
  */
 
 /* eslint no-undef: 0 */
-const {
-	FuzzTestBuilder,
-	describeSkipOnPlatform,
-	// eslint-disable-next-line @typescript-eslint/no-var-requires
-} = require("../helpers.js");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { FuzzTestBuilder, describeSkipOnPlatform } = require("../helpers.js");
 const path = require("path");
 
 // Signal handling in Node.js on Windows is only rudimentary supported.


### PR DESCRIPTION
The current test files show that file specific eslint rule configurations got out of hand. 

eslint rules should be configured according to the project’s needs. E.g. the ones which are normally disabled on a per file basis can safely be disabled globally.