### PR TITLE
bugfix: PP instrumentation handling async assignments/declarations

### DIFF
--- a/tests/bug-detectors/prototype-pollution.test.js
+++ b/tests/bug-detectors/prototype-pollution.test.js
@@ -230,6 +230,68 @@ describe("Prototype Pollution", () => {
 		expect(fuzzTest.stdout).toContain("Prototype Pollution");
 	});
 
+	it("Async assignment instrumentation", () => {
+		const fuzzTest = new FuzzTestBuilder()
+			.customHooks([
+				path.join(bugDetectorDirectory, "instrument-all.config.js"),
+			])
+			.dir(bugDetectorDirectory)
+			.fuzzEntryPoint("AsyncAssignment")
+			.verbose(true)
+			.build();
+		expect(() => {
+			fuzzTest.execute();
+		}).toThrowError(FuzzingExitCode);
+		expect(fuzzTest.stdout).toContain("Prototype Pollution");
+	});
+
+	it("Async variable declaration instrumentation", () => {
+		const fuzzTest = new FuzzTestBuilder()
+			.customHooks([
+				path.join(bugDetectorDirectory, "instrument-all.config.js"),
+			])
+			.dir(bugDetectorDirectory)
+			.fuzzEntryPoint("AsyncVariableDeclaration")
+			.verbose(true)
+			.build();
+		expect(() => {
+			fuzzTest.execute();
+		}).toThrowError(FuzzingExitCode);
+		expect(fuzzTest.stdout).toContain("Prototype Pollution");
+	});
+
+	it("Equal assignments should be instrumented", () => {
+		const fuzzTest = new FuzzTestBuilder()
+			.customHooks([
+				path.join(bugDetectorDirectory, "instrument-all.config.js"),
+			])
+			.dir(bugDetectorDirectory)
+			.fuzzEntryPoint("EqualExpressionInstrumentation")
+			.sync(true)
+			.verbose(true)
+			.build();
+		expect(() => {
+			fuzzTest.execute();
+		}).toThrowError(FuzzingExitCode);
+		expect(fuzzTest.stdout).toContain("Prototype Pollution");
+	});
+
+	it("Equal variable declarations should be instrumented", () => {
+		const fuzzTest = new FuzzTestBuilder()
+			.customHooks([
+				path.join(bugDetectorDirectory, "instrument-all.config.js"),
+			])
+			.dir(bugDetectorDirectory)
+			.fuzzEntryPoint("EqualVariableDeclarationsInstrumentation")
+			.sync(true)
+			.verbose(true)
+			.build();
+		expect(() => {
+			fuzzTest.execute();
+		}).toThrowError(FuzzingExitCode);
+		expect(fuzzTest.stdout).toContain("Prototype Pollution");
+	});
+
 	// Challenge to the future developer: make this test pass!
 	// it("Two-stage prototype pollution using instrumentation", () => {
 	// 	const fuzzTest = new FuzzTestBuilder()

--- a/tests/bug-detectors/prototype-pollution/fuzz.js
+++ b/tests/bug-detectors/prototype-pollution/fuzz.js
@@ -107,3 +107,59 @@ module.exports.TwoStagePollution = function (data) {
 	const b = a["__proto__"];
 	b.polluted = true; // This can currently not be detected.
 };
+
+module.exports.AsyncAssignment = async function (data) {
+	const fn = async () => {
+		return { __proto__: { polluted: true } };
+	};
+	let a;
+	a = await fn();
+};
+
+module.exports.AsyncVariableDeclaration = async function (data) {
+	const fn = async () => {
+		return { __proto__: { polluted: true } };
+	};
+	const a = await fn();
+};
+
+module.exports.EqualExpressionInstrumentation = function (data) {
+	const makeStatefulFn = () => {
+		let i = -1;
+		return () => {
+			i++;
+			if (i === 1) {
+				return { __proto__: { polluted: true } };
+			} else {
+				return {};
+			}
+		};
+	};
+	const fn = makeStatefulFn();
+	let a;
+	// PP instrumentation adds the next line to the instrumentation guard.
+	a = fn();
+	// If the next line is not instrumented, prototype pollution will not be detected.
+	a = fn();
+};
+
+module.exports.EqualVariableDeclarationsInstrumentation = function (data) {
+	const makeStatefulFn = () => {
+		let i = -1;
+		return () => {
+			i++;
+			if (i === 1) {
+				return { __proto__: { polluted: true } };
+			} else {
+				return {};
+			}
+		};
+	};
+	const fn = makeStatefulFn();
+
+	const a = fn();
+
+	(() => {
+		const a = fn();
+	})();
+};


### PR DESCRIPTION
Expressions like `a = await fn() ...` are not properly handled by the PP instrumentor. This PR adds one variable to the lambda wrapper and binds the original expression to that variable. Take it away :wink: 