### PR TITLE
fix: clean the error message stack

### DIFF
--- a/packages/core/callback.ts
+++ b/packages/core/callback.ts
@@ -33,11 +33,15 @@ export class Callbacks {
 	}
 
 	runAfterEachCallbacks() {
-		this._afterEachCallbacks.forEach((c) => c());
+		for (const c of this._afterEachCallbacks) {
+			c();
+		}
 	}
 
 	runBeforeEachCallbacks() {
-		this._beforeEachCallbacks.forEach((c) => c());
+		for (const c of this._beforeEachCallbacks) {
+			c();
+		}
 	}
 }
 


### PR DESCRIPTION
`forEach` leaves entries without code lines on the error stack.
Old behavior:
```
==10068== Prototype Pollution: Prototype of Object changed. Additional properties in object1: { 'test': 123 }
    at Array.forEach (<anonymous>)
```

New behavior:
```
==6954== Prototype Pollution: Prototype of Object changed. Additional properties in object1: { 'test': 123 }

```

The accidental newline makes the error stand out!
I wonder, if we could rerun the main entry point in a way that tells us which statement exactly causes prototype pollution. 