### PR TITLE
Add release canary test

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,3 +23,21 @@ jobs:
         run: npm publish --workspaces --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_ACCESS_TOKEN}}
+
+  end-to-end:
+    name: end-to-end
+    runs-on: ubuntu-20.04
+    needs: ["release"]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "npm"
+          registry-url: https://registry.npmjs.org
+      - name: build-example
+        run: cd end-to-end && npm install && npm run build
+      - name: run tests
+        run: cd end-to-end && npx jest

--- a/end-to-end/.gitignore
+++ b/end-to-end/.gitignore
@@ -1,0 +1,2 @@
+**/package-lock.json
+**/.cifuzz-corpus

--- a/end-to-end/.jazzerjsrc
+++ b/end-to-end/.jazzerjsrc
@@ -1,0 +1,4 @@
+{
+	"includes": ["target"],
+	"excludes": ["node_modules"]
+}

--- a/end-to-end/README.md
+++ b/end-to-end/README.md
@@ -1,0 +1,10 @@
+# Jazzer End to End Canary Test
+
+This is the code from `examples/jest_typescript_integration` with a single
+change to `package.json`: the `@jazzer.js/jest-runner` dependency is now set to
+version `*`. This project is meant to be run in our release pipeline after the
+release has been created to do a final check to make sure that nothing is broken
+in our packaging.
+
+The Typescript integration example was chosen as that should exercise more of
+jazzer.js than the other examples.

--- a/end-to-end/integration.fuzz.ts
+++ b/end-to-end/integration.fuzz.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import "@jazzer.js/jest-runner";
+import * as target from "./target";
+
+describe("Target", () => {
+	it.fuzz("executes sync methods", (data: Buffer) => {
+		target.fuzzMe(data);
+	});
+
+	it.fuzz("executes async methods", async (data: Buffer) => {
+		await target.asyncFuzzMe(data);
+	});
+
+	it.fuzz(
+		"executes methods with a done callback",
+		(data: Buffer, done: (e?: Error) => void) => {
+			target.callbackFuzzMe(data, done);
+		},
+	);
+});

--- a/end-to-end/integration.test.ts
+++ b/end-to-end/integration.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as target from "./target";
+
+describe("My describe", () => {
+	it("My normal Jest test", () => {
+		expect(1).toEqual(1);
+	});
+
+	it("My done callback Jest test", (done) => {
+		expect(1).toEqual(1);
+		done();
+	});
+
+	it("My async Jest test", async () => {
+		expect(1).toEqual(1);
+	});
+
+	it("Test target function", () => {
+		const data = Buffer.from("a");
+		target.fuzzMe(data);
+	});
+});

--- a/end-to-end/jest.config.ts
+++ b/end-to-end/jest.config.ts
@@ -1,0 +1,25 @@
+import type { Config } from "jest";
+
+const config: Config = {
+	verbose: true,
+	projects: [
+		{
+			displayName: "Jest",
+			preset: "ts-jest",
+		},
+		{
+			displayName: {
+				name: "Jazzer.js",
+				color: "cyan",
+			},
+			preset: "ts-jest",
+			runner: "@jazzer.js/jest-runner",
+			testEnvironment: "node",
+			testMatch: ["<rootDir>/*.fuzz.[jt]s"],
+		},
+	],
+	coveragePathIgnorePatterns: ["/node_modules/", "/dist/"],
+	modulePathIgnorePatterns: ["/node_modules", "/dist/"],
+};
+
+export default config;

--- a/end-to-end/package.json
+++ b/end-to-end/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "jest_typescript_integration",
+	"version": "1.0.0",
+	"description": "An example showing how Jazzer.js integrates with Jest and TypeScript",
+	"scripts": {
+		"build": "tsc",
+		"dryRun": "jest",
+		"fuzz": "JAZZER_FUZZ=1 jest --coverage",
+		"coverage": "jest --coverage"
+	},
+	"devDependencies": {
+		"@jazzer.js/jest-runner": "*",
+		"@types/jest": "^29.4.0",
+		"jest": "^29.4.1",
+		"ts-jest": "^29.0.5",
+		"ts-node": "^10.9.1",
+		"typescript": "^4.9.5"
+	}
+}

--- a/end-to-end/target.ts
+++ b/end-to-end/target.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function fuzzMe(data: Buffer) {
+	const s = data.toString();
+	if (s.length !== 16) {
+		return;
+	}
+	if (
+		s.slice(0, 8) === "Awesome " &&
+		s.slice(8, 15) === "Fuzzing" &&
+		s[15] === "!"
+	) {
+		throw Error("Welcome to Awesome Fuzzing!");
+	}
+}
+
+export function callbackFuzzMe(data: Buffer, done: (e?: Error) => void) {
+	// Use setImmediate here to unblock the event loop but still have better
+	// performance compared to setTimeout.
+	setImmediate(() => {
+		try {
+			fuzzMe(data);
+			done();
+		} catch (e: unknown) {
+			if (e instanceof Error) {
+				done(e);
+			} else {
+				done(new Error(`Error: ${e}`));
+			}
+		}
+	});
+}
+
+export async function asyncFuzzMe(data: Buffer) {
+	return new Promise((resolve, reject) => {
+		callbackFuzzMe(data, (e?: Error) => {
+			if (e) {
+				reject(e);
+			} else {
+				resolve(null);
+			}
+		});
+	});
+}

--- a/end-to-end/tsconfig.json
+++ b/end-to-end/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "node",
+		"allowJs": true,
+		"rootDir": ".",
+		"outDir": "./dist",
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"declaration": true,
+		"composite": true,
+		"sourceMap": true
+	}
+}


### PR DESCRIPTION
This adds a test to the release pipeline after the release has been created. It will run a duplicate of `examples/jest_typescript_integration` except with the `jest-runner` dependency is set to pull from npm rather than a local file reference.