### PR TITLE
Add eslint header plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,10 +14,12 @@
 	"overrides": [
 		{
 			"files": ["*.js", "*.ts"],
+			"plugins": ["header"],
 			"rules": {
 				"@typescript-eslint/no-var-requires": "off",
 				"@typescript-eslint/ban-ts-comment": "off",
-				"@typescript-eslint/no-unused-vars": "off"
+				"@typescript-eslint/no-unused-vars": "off",
+				"header/header": [2, ".header.js"]
 			}
 		},
 		{

--- a/.header.js
+++ b/.header.js
@@ -13,7 +13,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-const fs = require("fs");
-
-fs.writeFileSync("FRIENDLY", "");

--- a/examples/bug-detectors/command-injection/custom-hooks.js
+++ b/examples/bug-detectors/command-injection/custom-hooks.js
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Examples showcasing the custom hooks API
  */
 
 const { registerReplaceHook } = require("@jazzer.js/hooking");

--- a/examples/bug-detectors/prototype-pollution/config.js
+++ b/examples/bug-detectors/prototype-pollution/config.js
@@ -1,4 +1,19 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const {
 	getBugDetectorConfiguration,
 	// eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/examples/custom-hooks/custom-hooks.js
+++ b/examples/custom-hooks/custom-hooks.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Examples showcasing the custom hooks API
  */
 
 const {

--- a/examples/custom-hooks/fuzz.js
+++ b/examples/custom-hooks/fuzz.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // The code in this file is based on the examples available in JSFuzz:
 // https://gitlab.com/gitlab-org/security-products/analyzers/fuzzers/jsfuzz/-/blob/34a694a8c73bfe0895c4e24784ba5b6dfe964b94/examples/jpeg/fuzz.js
 // The original code is available under the Apache License 2.0.

--- a/examples/jest_integration/integration.fuzz.js
+++ b/examples/jest_integration/integration.fuzz.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/jest_integration/integration.test.js
+++ b/examples/jest_integration/integration.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/jest_integration/target.js
+++ b/examples/jest_integration/target.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/jest_integration/worker.fuzz.js
+++ b/examples/jest_integration/worker.fuzz.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/jest_integration/workerGoldenReference.test.js
+++ b/examples/jest_integration/workerGoldenReference.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/jest_typescript_integration/jest.config.ts
+++ b/examples/jest_typescript_integration/jest.config.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type { Config } from "jest";
 
 const config: Config = {

--- a/examples/jpeg/fuzz.js
+++ b/examples/jpeg/fuzz.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // The code in this file is based on the examples available in JSFuzz:
 // https://gitlab.com/gitlab-org/security-products/analyzers/fuzzers/jsfuzz/-/blob/34a694a8c73bfe0895c4e24784ba5b6dfe964b94/examples/jpeg/fuzz.js
 // The original code is available under the Apache License 2.0.

--- a/examples/jpeg_es6/fuzz.js
+++ b/examples/jpeg_es6/fuzz.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // The code in this file is based on the examples available in JSFuzz:
 // https://gitlab.com/gitlab-org/security-products/analyzers/fuzzers/jsfuzz/-/blob/34a694a8c73bfe0895c4e24784ba5b6dfe964b94/examples/jpeg/fuzz.js
 // The original code is available under the Apache License 2.0.

--- a/examples/js-yaml/fuzz.ts
+++ b/examples/js-yaml/fuzz.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/maze/fuzz.js
+++ b/examples/maze/fuzz.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/protobufjs/fuzz.js
+++ b/examples/protobufjs/fuzz.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import proto from "protobufjs";
 import { temporaryWriteSync } from "tempy";
 

--- a/examples/spectral/spectral-example.js
+++ b/examples/spectral/spectral-example.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/xml/fuzz.js
+++ b/examples/xml/fuzz.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // The code in this file is based on the examples available in JSFuzz:
 // https://gitlab.com/gitlab-org/security-products/analyzers/fuzzers/jsfuzz/-/blob/34a694a8c73bfe0895c4e24784ba5b6dfe964b94/examples/xml/fuzz.js
 // The original code is available under the Apache License 2.0.

--- a/fuzztests/runFuzzTests.js
+++ b/fuzztests/runFuzzTests.js
@@ -1,4 +1,19 @@
 #!/usr/bin/node
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 // Helper script that searches for Jest fuzz tests in the current directory and
 // executes them in new processes using the found fuzz test names.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
 				"@typescript-eslint/eslint-plugin": "^6.2.1",
 				"eslint": "^8.46.0",
 				"eslint-config-prettier": "^8.9.0",
+				"eslint-plugin-header": "^3.1.1",
 				"eslint-plugin-jest": "^27.2.3",
 				"eslint-plugin-markdownlint": "^0.4.1",
 				"husky": "^8.0.3",
@@ -3271,6 +3272,15 @@
 			},
 			"peerDependencies": {
 				"eslint": ">=7.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-header": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
+			"integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
+			"dev": true,
+			"peerDependencies": {
+				"eslint": ">=7.7.0"
 			}
 		},
 		"node_modules/eslint-plugin-jest": {
@@ -11618,6 +11628,13 @@
 			"version": "8.9.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.9.0.tgz",
 			"integrity": "sha512-+sbni7NfVXnOpnRadUA8S28AUlsZt9GjgFvABIRL9Hkn8KqNzOp+7Lw4QWtrwn20KzU3wqu1QoOj2m+7rKRqkA==",
+			"dev": true,
+			"requires": {}
+		},
+		"eslint-plugin-header": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
+			"integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
 			"dev": true,
 			"requires": {}
 		},

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"@typescript-eslint/eslint-plugin": "^6.2.1",
 		"eslint": "^8.46.0",
 		"eslint-config-prettier": "^8.9.0",
+		"eslint-plugin-header": "^3.1.1",
 		"eslint-plugin-jest": "^27.2.3",
 		"eslint-plugin-markdownlint": "^0.4.1",
 		"husky": "^8.0.3",

--- a/packages/core/FuzzedDataProvider.test.ts
+++ b/packages/core/FuzzedDataProvider.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/core/FuzzedDataProvider.ts
+++ b/packages/core/FuzzedDataProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/core/cli.ts
+++ b/packages/core/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/core/finding.ts
+++ b/packages/core/finding.ts
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 import process from "process";

--- a/packages/core/options.ts
+++ b/packages/core/options.ts
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 import * as tmp from "tmp";

--- a/packages/fuzzer/fuzzer.test.ts
+++ b/packages/fuzzer/fuzzer.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/fuzzer/fuzzer.ts
+++ b/packages/fuzzer/fuzzer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/hooking/hook.ts
+++ b/packages/hooking/hook.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/hooking/index.ts
+++ b/packages/hooking/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/instrumentor/instrument.test.ts
+++ b/packages/instrumentor/instrument.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/instrumentor/plugins/codeCoverage.test.ts
+++ b/packages/instrumentor/plugins/codeCoverage.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/instrumentor/plugins/codeCoverage.ts
+++ b/packages/instrumentor/plugins/codeCoverage.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/instrumentor/plugins/compareHooks.test.ts
+++ b/packages/instrumentor/plugins/compareHooks.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/instrumentor/plugins/compareHooks.ts
+++ b/packages/instrumentor/plugins/compareHooks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/instrumentor/plugins/functionHooks.test.ts
+++ b/packages/instrumentor/plugins/functionHooks.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/instrumentor/plugins/functionHooks.ts
+++ b/packages/instrumentor/plugins/functionHooks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/instrumentor/plugins/helpers.ts
+++ b/packages/instrumentor/plugins/helpers.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { NumericLiteral } from "@babel/types";
 import { types } from "@babel/core";
 import * as crypto from "crypto";

--- a/packages/instrumentor/plugins/testhelpers.ts
+++ b/packages/instrumentor/plugins/testhelpers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/jest-runner/config.test.ts
+++ b/packages/jest-runner/config.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/jest-runner/config.ts
+++ b/packages/jest-runner/config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/jest-runner/corpus.test.ts
+++ b/packages/jest-runner/corpus.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/jest-runner/corpus.ts
+++ b/packages/jest-runner/corpus.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/jest-runner/errorUtils.test.ts
+++ b/packages/jest-runner/errorUtils.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/jest-runner/errorUtils.ts
+++ b/packages/jest-runner/errorUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/jest-runner/fuzz.test.ts
+++ b/packages/jest-runner/fuzz.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/jest-runner/fuzz.ts
+++ b/packages/jest-runner/fuzz.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/jest-runner/index.ts
+++ b/packages/jest-runner/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/jest-runner/worker.ts
+++ b/packages/jest-runner/worker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/code_coverage/sample_fuzz_test/custom-hooks.js
+++ b/tests/code_coverage/sample_fuzz_test/custom-hooks.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const { registerReplaceHook } = require("@jazzer.js/hooking");
 
 registerReplaceHook("foo", "lib", false, () => {

--- a/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib+codeCoverage-fuzz.json
+++ b/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib+codeCoverage-fuzz.json
@@ -118,55 +118,55 @@
 	"lib.js": {
 		"statementMap": {
 			"0": {
-				"start": { "line": 2, "column": 1 },
-				"end": { "line": 2, "column": 29 }
+				"start": { "line": 18, "column": 1 },
+				"end": { "line": 18, "column": 29 }
 			},
 			"1": {
-				"start": { "line": 3, "column": 1 },
-				"end": { "line": 5, "column": 2 }
+				"start": { "line": 19, "column": 1 },
+				"end": { "line": 21, "column": 2 }
 			},
 			"2": {
-				"start": { "line": 4, "column": 2 },
-				"end": { "line": 4, "column": 11 }
+				"start": { "line": 20, "column": 2 },
+				"end": { "line": 20, "column": 11 }
 			},
 			"3": {
-				"start": { "line": 6, "column": 1 },
-				"end": { "line": 6, "column": 11 }
+				"start": { "line": 22, "column": 1 },
+				"end": { "line": 22, "column": 11 }
 			},
 			"4": {
-				"start": { "line": 9, "column": 0 },
-				"end": { "line": 11, "column": 2 }
+				"start": { "line": 25, "column": 0 },
+				"end": { "line": 27, "column": 2 }
 			}
 		},
 		"fnMap": {
 			"0": {
 				"name": "foo",
 				"decl": {
-					"start": { "line": 1, "column": 9 },
-					"end": { "line": 1, "column": 12 }
+					"start": { "line": 17, "column": 9 },
+					"end": { "line": 17, "column": 12 }
 				},
 				"loc": {
-					"start": { "line": 1, "column": 16 },
-					"end": { "line": 7, "column": 1 }
+					"start": { "line": 17, "column": 16 },
+					"end": { "line": 23, "column": 1 }
 				},
-				"line": 1
+				"line": 17
 			}
 		},
 		"branchMap": {
 			"0": {
 				"loc": {
-					"start": { "line": 3, "column": 1 },
-					"end": { "line": 5, "column": 2 }
+					"start": { "line": 19, "column": 1 },
+					"end": { "line": 21, "column": 2 }
 				},
 				"type": "if",
 				"locations": [
 					{
-						"start": { "line": 3, "column": 1 },
-						"end": { "line": 5, "column": 2 }
+						"start": { "line": 19, "column": 1 },
+						"end": { "line": 21, "column": 2 }
 					},
 					{ "start": {}, "end": {} }
 				],
-				"line": 3
+				"line": 19
 			}
 		},
 		"s": { "0": 1, "1": 1, "2": 1, "3": 0, "4": 1 },

--- a/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib+customHooks.json
+++ b/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib+customHooks.json
@@ -2,30 +2,30 @@
 	"custom-hooks.js": {
 		"statementMap": {
 			"0": {
-				"start": { "line": 1, "column": 32 },
-				"end": { "line": 1, "column": 61 }
+				"start": { "line": 17, "column": 32 },
+				"end": { "line": 17, "column": 61 }
 			},
 			"1": {
-				"start": { "line": 3, "column": 0 },
-				"end": { "line": 5, "column": 3 }
+				"start": { "line": 19, "column": 0 },
+				"end": { "line": 21, "column": 3 }
 			},
 			"2": {
-				"start": { "line": 4, "column": 1 },
-				"end": { "line": 4, "column": 37 }
+				"start": { "line": 20, "column": 1 },
+				"end": { "line": 20, "column": 37 }
 			}
 		},
 		"fnMap": {
 			"0": {
 				"name": "(anonymous_0)",
 				"decl": {
-					"start": { "line": 3, "column": 41 },
-					"end": { "line": 3, "column": 42 }
+					"start": { "line": 19, "column": 41 },
+					"end": { "line": 19, "column": 42 }
 				},
 				"loc": {
-					"start": { "line": 3, "column": 47 },
-					"end": { "line": 5, "column": 1 }
+					"start": { "line": 19, "column": 47 },
+					"end": { "line": 21, "column": 1 }
 				},
-				"line": 3
+				"line": 19
 			}
 		},
 		"branchMap": {},
@@ -102,55 +102,55 @@
 	"lib.js": {
 		"statementMap": {
 			"0": {
-				"start": { "line": 2, "column": 1 },
-				"end": { "line": 2, "column": 29 }
+				"start": { "line": 18, "column": 1 },
+				"end": { "line": 18, "column": 29 }
 			},
 			"1": {
-				"start": { "line": 3, "column": 1 },
-				"end": { "line": 5, "column": 2 }
+				"start": { "line": 19, "column": 1 },
+				"end": { "line": 21, "column": 2 }
 			},
 			"2": {
-				"start": { "line": 4, "column": 2 },
-				"end": { "line": 4, "column": 11 }
+				"start": { "line": 20, "column": 2 },
+				"end": { "line": 20, "column": 11 }
 			},
 			"3": {
-				"start": { "line": 6, "column": 1 },
-				"end": { "line": 6, "column": 11 }
+				"start": { "line": 22, "column": 1 },
+				"end": { "line": 22, "column": 11 }
 			},
 			"4": {
-				"start": { "line": 9, "column": 0 },
-				"end": { "line": 11, "column": 2 }
+				"start": { "line": 25, "column": 0 },
+				"end": { "line": 27, "column": 2 }
 			}
 		},
 		"fnMap": {
 			"0": {
 				"name": "foo",
 				"decl": {
-					"start": { "line": 1, "column": 9 },
-					"end": { "line": 1, "column": 12 }
+					"start": { "line": 17, "column": 9 },
+					"end": { "line": 17, "column": 12 }
 				},
 				"loc": {
-					"start": { "line": 1, "column": 16 },
-					"end": { "line": 7, "column": 1 }
+					"start": { "line": 17, "column": 16 },
+					"end": { "line": 23, "column": 1 }
 				},
-				"line": 1
+				"line": 17
 			}
 		},
 		"branchMap": {
 			"0": {
 				"loc": {
-					"start": { "line": 3, "column": 1 },
-					"end": { "line": 5, "column": 2 }
+					"start": { "line": 19, "column": 1 },
+					"end": { "line": 21, "column": 2 }
 				},
 				"type": "if",
 				"locations": [
 					{
-						"start": { "line": 3, "column": 1 },
-						"end": { "line": 5, "column": 2 }
+						"start": { "line": 19, "column": 1 },
+						"end": { "line": 21, "column": 2 }
 					},
 					{ "start": {}, "end": {} }
 				],
-				"line": 3
+				"line": 19
 			}
 		},
 		"s": { "0": 0, "1": 0, "2": 0, "3": 0, "4": 1 },

--- a/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib+otherCodeCoverage-fuzz.json
+++ b/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib+otherCodeCoverage-fuzz.json
@@ -127,55 +127,55 @@
 	"lib.js": {
 		"statementMap": {
 			"0": {
-				"start": { "line": 2, "column": 1 },
-				"end": { "line": 2, "column": 29 }
+				"start": { "line": 18, "column": 1 },
+				"end": { "line": 18, "column": 29 }
 			},
 			"1": {
-				"start": { "line": 3, "column": 1 },
-				"end": { "line": 5, "column": 2 }
+				"start": { "line": 19, "column": 1 },
+				"end": { "line": 21, "column": 2 }
 			},
 			"2": {
-				"start": { "line": 4, "column": 2 },
-				"end": { "line": 4, "column": 11 }
+				"start": { "line": 20, "column": 2 },
+				"end": { "line": 20, "column": 11 }
 			},
 			"3": {
-				"start": { "line": 6, "column": 1 },
-				"end": { "line": 6, "column": 11 }
+				"start": { "line": 22, "column": 1 },
+				"end": { "line": 22, "column": 11 }
 			},
 			"4": {
-				"start": { "line": 9, "column": 0 },
-				"end": { "line": 11, "column": 2 }
+				"start": { "line": 25, "column": 0 },
+				"end": { "line": 27, "column": 2 }
 			}
 		},
 		"fnMap": {
 			"0": {
 				"name": "foo",
 				"decl": {
-					"start": { "line": 1, "column": 9 },
-					"end": { "line": 1, "column": 12 }
+					"start": { "line": 17, "column": 9 },
+					"end": { "line": 17, "column": 12 }
 				},
 				"loc": {
-					"start": { "line": 1, "column": 16 },
-					"end": { "line": 7, "column": 1 }
+					"start": { "line": 17, "column": 16 },
+					"end": { "line": 23, "column": 1 }
 				},
-				"line": 1
+				"line": 17
 			}
 		},
 		"branchMap": {
 			"0": {
 				"loc": {
-					"start": { "line": 3, "column": 1 },
-					"end": { "line": 5, "column": 2 }
+					"start": { "line": 19, "column": 1 },
+					"end": { "line": 21, "column": 2 }
 				},
 				"type": "if",
 				"locations": [
 					{
-						"start": { "line": 3, "column": 1 },
-						"end": { "line": 5, "column": 2 }
+						"start": { "line": 19, "column": 1 },
+						"end": { "line": 21, "column": 2 }
 					},
 					{ "start": {}, "end": {} }
 				],
-				"line": 3
+				"line": 19
 			}
 		},
 		"s": { "0": 1, "1": 1, "2": 1, "3": 0, "4": 1 },

--- a/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib.json
+++ b/tests/code_coverage/sample_fuzz_test/expected_coverage/fuzz+lib.json
@@ -66,55 +66,55 @@
 	"lib.js": {
 		"statementMap": {
 			"0": {
-				"start": { "line": 2, "column": 1 },
-				"end": { "line": 2, "column": 29 }
+				"start": { "line": 18, "column": 1 },
+				"end": { "line": 18, "column": 29 }
 			},
 			"1": {
-				"start": { "line": 3, "column": 1 },
-				"end": { "line": 5, "column": 2 }
+				"start": { "line": 19, "column": 1 },
+				"end": { "line": 21, "column": 2 }
 			},
 			"2": {
-				"start": { "line": 4, "column": 2 },
-				"end": { "line": 4, "column": 11 }
+				"start": { "line": 20, "column": 2 },
+				"end": { "line": 20, "column": 11 }
 			},
 			"3": {
-				"start": { "line": 6, "column": 1 },
-				"end": { "line": 6, "column": 11 }
+				"start": { "line": 22, "column": 1 },
+				"end": { "line": 22, "column": 11 }
 			},
 			"4": {
-				"start": { "line": 9, "column": 0 },
-				"end": { "line": 11, "column": 2 }
+				"start": { "line": 25, "column": 0 },
+				"end": { "line": 27, "column": 2 }
 			}
 		},
 		"fnMap": {
 			"0": {
 				"name": "foo",
 				"decl": {
-					"start": { "line": 1, "column": 9 },
-					"end": { "line": 1, "column": 12 }
+					"start": { "line": 17, "column": 9 },
+					"end": { "line": 17, "column": 12 }
 				},
 				"loc": {
-					"start": { "line": 1, "column": 16 },
-					"end": { "line": 7, "column": 1 }
+					"start": { "line": 17, "column": 16 },
+					"end": { "line": 23, "column": 1 }
 				},
-				"line": 1
+				"line": 17
 			}
 		},
 		"branchMap": {
 			"0": {
 				"loc": {
-					"start": { "line": 3, "column": 1 },
-					"end": { "line": 5, "column": 2 }
+					"start": { "line": 19, "column": 1 },
+					"end": { "line": 21, "column": 2 }
 				},
 				"type": "if",
 				"locations": [
 					{
-						"start": { "line": 3, "column": 1 },
-						"end": { "line": 5, "column": 2 }
+						"start": { "line": 19, "column": 1 },
+						"end": { "line": 21, "column": 2 }
 					},
 					{ "start": {}, "end": {} }
 				],
-				"line": 3
+				"line": 19
 			}
 		},
 		"s": { "0": 1, "1": 1, "2": 1, "3": 0, "4": 1 },

--- a/tests/code_coverage/sample_fuzz_test/fuzz.js
+++ b/tests/code_coverage/sample_fuzz_test/fuzz.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/code_coverage/sample_fuzz_test/lib.js
+++ b/tests/code_coverage/sample_fuzz_test/lib.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 function foo(a) {
 	console.log("original foo");
 	if (a > 10) {

--- a/tests/done_callback/fuzz.js
+++ b/tests/done_callback/fuzz.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/promise/fuzz.js
+++ b/tests/promise/fuzz.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/return_values/exampleCode/code.js
+++ b/tests/return_values/exampleCode/code.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const ReturnType = {
 	SYNC: "sync",
 	ASYNC: "async",

--- a/tests/string_compare/fuzz.js
+++ b/tests/string_compare/fuzz.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/switch/fuzz.js
+++ b/tests/switch/fuzz.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/timeout/fuzz.js
+++ b/tests/timeout/fuzz.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/value_profiling/fuzz.js
+++ b/tests/value_profiling/fuzz.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Code Intelligence GmbH
+ * Copyright 2023 Code Intelligence GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This plugin automatically checks the existence of correct copyright headers and adds them via the `fix` command.