### PR TITLE
bugfix: properly stop fuzzing when no error received

### DIFF
--- a/packages/core/core.ts
+++ b/packages/core/core.ts
@@ -272,9 +272,8 @@ function stopFuzzing(
 				`ERROR: Received no error, but expected one of [${expectedErrors}].`,
 			);
 			stopFuzzing(ERROR_UNEXPECTED_CODE);
-		} else {
-			// No error received, no error expected.
-			stopFuzzing(0);
+		} else if (forceShutdownWithCode === 0) {
+			stopFuzzing(forceShutdownWithCode);
 		}
 		return;
 	}

--- a/packages/core/core.ts
+++ b/packages/core/core.ts
@@ -271,8 +271,9 @@ function stopFuzzing(
 				`ERROR: Received no error, but expected one of [${expectedErrors}].`,
 			);
 			stopFuzzing(ERROR_UNEXPECTED_CODE);
-		} else if (forceShutdownWithCode === 0) {
-			stopFuzzing(forceShutdownWithCode);
+		} else {
+			// No error received, no error expected.
+			stopFuzzing(0);
 		}
 		return;
 	}

--- a/packages/core/core.ts
+++ b/packages/core/core.ts
@@ -266,6 +266,7 @@ function stopFuzzing(
 
 	// No error found, check if one is expected or an exit code should be enforced.
 	if (!err) {
+		console.log("[DEBUG]: forceShutdownWithCode: ", forceShutdownWithCode);
 		if (expectedErrors.length) {
 			console.error(
 				`ERROR: Received no error, but expected one of [${expectedErrors}].`,

--- a/tests/bug-detectors/command-injection.test.js
+++ b/tests/bug-detectors/command-injection.test.js
@@ -154,6 +154,7 @@ describe("Command injection", () => {
 			.sync(false)
 			.fuzzEntryPoint("forkFRIENDLY")
 			.dir(bugDetectorDirectory)
+			.verbose(true)
 			.build();
 		fuzzTest.execute();
 		expect(fs.existsSync(friendlyFilePath)).toBeTruthy();


### PR DESCRIPTION
The addition of signal handling for SIGINT/SIGSEGV introduced a bug where fuzzing process would not stop after reaching the desired number of runs. This PR fixes that.