### PR TITLE
Prefer env variables over configuration file values

### DIFF
--- a/docs/fuzz-settings.md
+++ b/docs/fuzz-settings.md
@@ -14,11 +14,10 @@ In general the following preference applies with increasing priority:
 
 - Default values from the [`defaultOptions`](../packages/core/options.ts) object
   (names in camel case format, e.g. `fuzzTarget`)
+- Configuration file values (e.g. `jazzerjsrc` or Jest configuration files)
 - Environment variables (names in upper snake case format with `JAZZER_` prefix,
   e.g. `JAZZER_FUZZ_TARGET=Foo`)
 - CLI arguments (names in lower snake case format, e.g. `--fuzz_target=Foo`)
-- Integration specific configuration (e.g. `jazzerjsrc` or Jest configuration
-  files)
 
 **Note**: The CLI provides abbreviations for common arguments, e.g. `--includes`
 can be abbreviated to `-i`. Only the main argument name is supported in other

--- a/packages/core/cli.ts
+++ b/packages/core/cli.ts
@@ -18,7 +18,12 @@
 import yargs, { Argv } from "yargs";
 import { startFuzzing } from "./core";
 import { prepareArgs } from "./utils";
-import { defaultOptions, processOptions, fromSnakeCase } from "./options";
+import {
+	buildOptions,
+	defaultOptions,
+	ParameterResolverIndex,
+	setParameterResolverValue,
+} from "./options";
 
 // Use yargs to parse command line arguments and provide a nice CLI experience.
 // Default values are provided by the options module and must not be set by yargs.
@@ -228,9 +233,12 @@ yargs(process.argv.slice(2))
 		},
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		(args: any) => {
-			const options = prepareArgs(args);
+			setParameterResolverValue(
+				ParameterResolverIndex.CommandLineArguments,
+				prepareArgs(args),
+			);
 			// noinspection JSIgnoredPromiseFromCall
-			startFuzzing(processOptions(options, fromSnakeCase));
+			startFuzzing(buildOptions());
 		},
 	)
 	.help().argv;

--- a/packages/core/core.ts
+++ b/packages/core/core.ts
@@ -385,4 +385,10 @@ export function wrapFuzzFunctionForBugDetection(
 // Export public API from within core module for easy access.
 export * from "./api";
 export { FuzzedDataProvider } from "./FuzzedDataProvider";
-export { Options, processOptions, defaultOptions } from "./options";
+export {
+	buildOptions,
+	defaultOptions,
+	Options,
+	ParameterResolverIndex,
+	setParameterResolverValue,
+} from "./options";

--- a/packages/jest-runner/config.ts
+++ b/packages/jest-runner/config.ts
@@ -15,7 +15,12 @@
  */
 
 import { cosmiconfigSync } from "cosmiconfig";
-import { processOptions, Options } from "@jazzer.js/core";
+import {
+	buildOptions,
+	Options,
+	setParameterResolverValue,
+	ParameterResolverIndex,
+} from "@jazzer.js/core";
 
 // Lookup `Options` via the `.jazzerjsrc` configuration files.
 export function loadConfig(
@@ -33,7 +38,8 @@ export function loadConfig(
 	if (process.env.JAZZER_FUZZ) {
 		config.mode = "fuzzing";
 	}
-	// Merge explicitly passed in options.
+	// Merge explicitly passed in options, e.g. coverage settings from Jest.
 	Object.assign(config, options);
-	return processOptions(config);
+	setParameterResolverValue(ParameterResolverIndex.ConfigurationFile, config);
+	return buildOptions();
 }


### PR DESCRIPTION
Configuration files are harder to change than other means of providing parameters. Hence, the priority of configuration file values is reduced to the lowest one above the default settings.