### PR TITLE
Always log internal messages to stderr

### DIFF
--- a/examples/custom-hooks/custom-hooks.js
+++ b/examples/custom-hooks/custom-hooks.js
@@ -62,7 +62,7 @@ registerReplaceHook(
 	"jpeg-js",
 	false,
 	() => {
-		console.log(
+		console.error(
 			`[jpeg-js] Called custom hook instead of the original function buildHuffmanTable()`,
 		);
 	},
@@ -78,7 +78,7 @@ registerReplaceHook(
 	"jpeg-js",
 	false,
 	(thisPtr, params, hookId, origFn) => {
-		console.log(
+		console.error(
 			`[jpeg-js] Called custom hook instead of the original function prepareComponents()`,
 		);
 		const frame = params[0]; // our hooked function only has one argument: frame
@@ -97,7 +97,7 @@ registerBeforeHook(
 	"jpeg-js",
 	false,
 	() => {
-		console.log(
+		console.error(
 			`[jpeg-js] [before] Called hooked function before calling resetMaxMemoryUsage()`,
 		);
 	},
@@ -113,7 +113,7 @@ registerAfterHook(
 	"jpeg-js",
 	false,
 	(thisPtr, params, hookId, origFnResult) => {
-		console.log(
+		console.error(
 			`[jpeg-js] [after] Called hooked function after calling resetMaxMemoryUsage() with original result ${origFnResult}`,
 		);
 	},

--- a/examples/jest_integration/workerGoldenReference.test.js
+++ b/examples/jest_integration/workerGoldenReference.test.js
@@ -107,6 +107,5 @@ describe("My describe", () => {
 });
 
 afterAll((done) => {
-	//console.log("startupTeardownCalls: ", startupTeardownCalls);
 	done();
 }, 1000);

--- a/examples/maze/fuzz.js
+++ b/examples/maze/fuzz.js
@@ -123,5 +123,5 @@ function hash(x, y) {
 }
 
 function printMaze() {
-	maze.forEach((line) => console.log(line.join("")));
+	maze.forEach((line) => console.error(line.join("")));
 }

--- a/examples/protobufjs/fuzz.js
+++ b/examples/protobufjs/fuzz.js
@@ -25,7 +25,7 @@ export function fuzz(data) {
 		const file = temporaryWriteSync(data);
 		const root = proto.loadSync(file);
 		if (root.toString().length >= 30) {
-			console.log("== Input: " + data.toString() + "\n== " + root.toString());
+			console.error("== Input: " + data.toString() + "\n== " + root.toString());
 		}
 	} catch (e) {
 		if (

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	"scripts": {
 		"prepare": "husky install",
 		"build": "tsc -b tsconfig.build.json",
-		"clean": "rimraf -g **/node_modules **/tests/**/package-lock.json **/examples/**/package-lock.json **/dist **/coverage packages/fuzzer/build packages/fuzzer/prebuilds",
+		"clean": "git clean -dfX",
 		"compile:watch": "tsc -b tsconfig.build.json --incremental --pretty --watch",
 		"test": "run-script-os",
 		"test:jest": "jest && npm run test --ws --if-present",

--- a/packages/core/core.ts
+++ b/packages/core/core.ts
@@ -81,7 +81,7 @@ export async function initFuzzing(options: Options): Promise<void> {
 	);
 
 	if (process.env.JAZZER_DEBUG) {
-		console.log(
+		console.error(
 			"INFO: [BugDetector] Loading bug detectors: \n   " +
 				possibleBugDetectorFiles.join("\n   "),
 		);
@@ -134,7 +134,7 @@ function getFilteredBugDetectorPaths(
 				);
 
 				if (shouldDisable) {
-					console.log(
+					console.error(
 						`Skip loading bug detector "${bugDetectorName}" because of user-provided pattern.`,
 					);
 				}
@@ -259,7 +259,7 @@ function stopFuzzing(
 	if (expectedErrors.length) {
 		const name = errorName(err);
 		if (expectedErrors.includes(name)) {
-			console.log(`INFO: Received expected error "${name}".`);
+			console.error(`INFO: Received expected error "${name}".`);
 			stopFuzzing(ERROR_EXPECTED_CODE);
 		} else {
 			printFinding(err);

--- a/packages/core/finding.ts
+++ b/packages/core/finding.ts
@@ -59,16 +59,16 @@ export function printFinding(error: unknown) {
 
 	if (error instanceof Error) {
 		errorMessage += error.message;
-		console.log(errorMessage);
+		console.error(errorMessage);
 		if (error.stack) {
-			console.log(cleanErrorStack(error));
+			console.error(cleanErrorStack(error));
 		}
 	} else if (typeof error === "string" || error instanceof String) {
 		errorMessage += error;
-		console.log(errorMessage);
+		console.error(errorMessage);
 	} else {
 		errorMessage += "unknown";
-		console.log(errorMessage);
+		console.error(errorMessage);
 	}
 }
 

--- a/packages/core/options.ts
+++ b/packages/core/options.ts
@@ -206,7 +206,7 @@ export function buildFuzzerOption(options: Options) {
 function logInfoAboutFuzzerOptions(fuzzerOptions: string[]) {
 	fuzzerOptions.slice(1).forEach((element) => {
 		if (element.length > 0 && element[0] != "-") {
-			console.log("INFO: using inputs from:", element);
+			console.error("INFO: using inputs from:", element);
 		}
 	});
 }

--- a/packages/fuzzer/coverage.ts
+++ b/packages/fuzzer/coverage.ts
@@ -45,7 +45,7 @@ export class CoverageTracker {
 		if (newNumCounters > this.currentNumCounters) {
 			addon.registerNewCounters(this.currentNumCounters, newNumCounters);
 			this.currentNumCounters = newNumCounters;
-			console.log(
+			console.error(
 				`INFO: New number of coverage counters ${this.currentNumCounters}`,
 			);
 		}

--- a/packages/hooking/manager.ts
+++ b/packages/hooking/manager.ts
@@ -133,7 +133,7 @@ export class HookManager {
 					await hookBuiltInFunction(hook);
 				} catch (e) {
 					if (process.env.JAZZER_DEBUG) {
-						console.log(
+						console.error(
 							"DEBUG: [Hook] Error when trying to hook the built-in function: " +
 								e,
 						);

--- a/packages/hooking/tracker.ts
+++ b/packages/hooking/tracker.ts
@@ -81,18 +81,18 @@ class HookTracker {
 	private _notApplied = new HookTable();
 
 	print() {
-		console.log("DEBUG: [Hook] Summary:");
-		console.log("DEBUG: [Hook]    Not applied: " + this._notApplied.length);
+		console.error("DEBUG: [Hook] Summary:");
+		console.error("DEBUG: [Hook]    Not applied: " + this._notApplied.length);
 		this._notApplied.serialize().forEach((hook) => {
-			console.log(`DEBUG: [Hook] not applied: ${hook.pkg} -> ${hook.target}`);
+			console.error(`DEBUG: [Hook] not applied: ${hook.pkg} -> ${hook.target}`);
 		});
-		console.log("DEBUG: [Hook]    Applied: " + this._applied.length);
+		console.error("DEBUG: [Hook]    Applied: " + this._applied.length);
 		this._applied.serialize().forEach((hook) => {
-			console.log(`DEBUG: [Hook] applied:     ${hook.pkg} -> ${hook.target}`);
+			console.error(`DEBUG: [Hook] applied:     ${hook.pkg} -> ${hook.target}`);
 		});
-		console.log("DEBUG: [Hook]    Available: " + this._available.length);
+		console.error("DEBUG: [Hook]    Available: " + this._available.length);
 		this._available.serialize().forEach((hook) => {
-			console.log(`DEBUG: [Hook] available:   ${hook.pkg} -> ${hook.target}`);
+			console.error(`DEBUG: [Hook] available:   ${hook.pkg} -> ${hook.target}`);
 		});
 	}
 
@@ -144,7 +144,7 @@ export const hookTracker = new HookTracker();
 export function logHooks(hooks: Hook[]) {
 	hooks.forEach((hook) => {
 		if (process.env.JAZZER_DEBUG) {
-			console.log(
+			console.error(
 				`DEBUG: Applied %s-hook in %s#%s`,
 				HookType[hook.type],
 				hook.pkg,

--- a/packages/instrumentor/instrument.ts
+++ b/packages/instrumentor/instrument.ts
@@ -149,7 +149,7 @@ export class Instrumentor {
 	}
 
 	private unloadInternalModules() {
-		console.log(
+		console.error(
 			"DEBUG: Unloading internal Jazzer.js modules for instrumentation...",
 		);
 		[

--- a/packages/instrumentor/plugins/functionHooks.test.ts
+++ b/packages/instrumentor/plugins/functionHooks.test.ts
@@ -42,7 +42,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -53,7 +53,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -82,7 +82,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -92,7 +92,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -123,7 +123,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -135,7 +135,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -165,7 +165,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -176,7 +176,7 @@ describe("function hooks instrumentation", () => {
 			|};
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -438,7 +438,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -453,7 +453,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -484,7 +484,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2)`;
@@ -500,7 +500,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -529,7 +529,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2)`;
@@ -546,7 +546,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -579,7 +579,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -598,7 +598,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -635,7 +635,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2)`;
@@ -657,7 +657,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -694,7 +694,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -708,7 +708,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -740,7 +740,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|a(1, 2);`;
@@ -758,7 +758,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|a(1, 2);`;
@@ -795,7 +795,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2)`;
@@ -813,7 +813,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -853,7 +853,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -874,7 +874,7 @@ describe("function hooks instrumentation", () => {
 			|}
 			|
 			|function bar(arg1) {
-			|  console.log(arg1);
+			|  console.error(arg1);
 			|}
 			|
 			|foo(1, 2);`;
@@ -977,14 +977,14 @@ function registerHook(
 
 //eslint-disable-next-line @typescript-eslint/no-explicit-any
 function withDebug(fn: () => void): jest.Mock<any, any> {
-	const log = console.log;
+	const error = console.error;
 	const mock = jest.fn();
-	console.log = mock;
+	console.error = mock;
 	process.env["JAZZER_DEBUG"] = "1";
 	try {
 		fn();
 	} finally {
-		console.log = log;
+		console.error = error;
 		delete process.env["JAZZER_DEBUG"];
 	}
 	return mock;

--- a/tests/bug-detectors/general.test.js
+++ b/tests/bug-detectors/general.test.js
@@ -29,8 +29,8 @@ describe("General tests", () => {
 	const errorPattern =
 		/Command Injection in execSync\(\): called with 'jaz_zer'/g;
 
-	function expectErrorToBePrintedOnce(output) {
-		const matches = output.match(errorPattern);
+	function expectErrorToBePrintedOnce(fuzzTest) {
+		const matches = fuzzTest.stderr.match(errorPattern);
 		expect(matches).toBeTruthy();
 		expect(matches.length).toBe(1);
 	}
@@ -65,7 +65,7 @@ describe("General tests", () => {
 			fuzzTest.execute();
 		}).toThrow(FuzzingExitCode);
 		expect(fs.existsSync(friendlyFilePath)).toBeFalsy();
-		expectErrorToBePrintedOnce(fuzzTest.stdout);
+		expectErrorToBePrintedOnce(fuzzTest);
 	});
 
 	it("Call with FRIENDLY string; ASYNC", () => {
@@ -101,7 +101,7 @@ describe("General tests", () => {
 			fuzzTest.execute();
 		}).toThrow(FuzzingExitCode);
 		expect(fs.existsSync(friendlyFilePath)).toBeFalsy();
-		expectErrorToBePrintedOnce(fuzzTest.stdout);
+		expectErrorToBePrintedOnce(fuzzTest);
 	});
 
 	it("Call with EVIL string; With done callback; With try/catch", () => {
@@ -115,7 +115,7 @@ describe("General tests", () => {
 			fuzzTest.execute();
 		}).toThrow(FuzzingExitCode);
 		expect(fs.existsSync(friendlyFilePath)).toBeFalsy();
-		expectErrorToBePrintedOnce(fuzzTest.stdout);
+		expectErrorToBePrintedOnce(fuzzTest);
 	});
 
 	it("Call with EVIL string; With done callback; With timeout", () => {
@@ -160,7 +160,7 @@ describe("General tests", () => {
 	it("Fork mode: Call with EVIL string; SYNC", () => {
 		// TODO: Fork mode does not work in the Windows-Server image used by github actions
 		if (process.platform === "win32") {
-			console.log(
+			console.error(
 				"// TODO: Fork mode does not work in the Windows-Server image used by github actions",
 			);
 			return;
@@ -179,7 +179,7 @@ describe("General tests", () => {
 	it("Fork mode: Call with FRIENDLY string; SYNC", () => {
 		// TODO: Fork mode does not work in the Windows-Server image used by github actions
 		if (process.platform === "win32") {
-			console.log(
+			console.error(
 				"// TODO: Fork mode does not work in the Windows-Server image used by github actions",
 			);
 			return;
@@ -198,7 +198,7 @@ describe("General tests", () => {
 	it("Fork mode: Call with EVIL string; ASYNC", () => {
 		// TODO: Fork mode does not work in the Windows-Server image used by github actions
 		if (process.platform === "win32") {
-			console.log(
+			console.error(
 				"// TODO: Fork mode does not work in the Windows-Server image used by github actions",
 			);
 			return;
@@ -217,7 +217,7 @@ describe("General tests", () => {
 	it("Fork mode: Call with FRIENDLY string; ASYNC", () => {
 		// TODO: Fork mode does not work in the Windows-Server image used by github actions
 		if (process.platform === "win32") {
-			console.log(
+			console.error(
 				"// TODO: Fork mode does not work in the Windows-Server image used by github actions",
 			);
 			return;
@@ -259,7 +259,7 @@ describe("General tests", () => {
 			fuzzTest.execute();
 		}).toThrow(JestRegressionExitCode);
 		expect(fs.existsSync(friendlyFilePath)).toBeFalsy();
-		expectErrorToBePrintedOnce(fuzzTest.stderr);
+		expectErrorToBePrintedOnce(fuzzTest);
 	});
 
 	it("Jest: Test with EVIL command; ASYNC", () => {
@@ -276,7 +276,7 @@ describe("General tests", () => {
 			fuzzTest.execute();
 		}).toThrow(JestRegressionExitCode);
 		expect(fs.existsSync(friendlyFilePath)).toBeFalsy();
-		expectErrorToBePrintedOnce(fuzzTest.stderr);
+		expectErrorToBePrintedOnce(fuzzTest);
 	});
 
 	it("Jest: Test with FRIENDLY command", () => {
@@ -322,7 +322,7 @@ describe("General tests", () => {
 			process.platform === "win32" ? JestRegressionExitCode : FuzzingExitCode,
 		);
 		expect(fs.existsSync(friendlyFilePath)).toBeFalsy();
-		expectErrorToBePrintedOnce(fuzzTest.stderr);
+		expectErrorToBePrintedOnce(fuzzTest);
 	});
 
 	it("Jest: Fuzzing mode; Test with FRIENDLY command", () => {
@@ -354,7 +354,7 @@ describe("General tests", () => {
 			fuzzTest.execute();
 		}).toThrow(JestRegressionExitCode);
 		expect(fs.existsSync(friendlyFilePath)).toBeFalsy();
-		expectErrorToBePrintedOnce(fuzzTest.stderr);
+		expectErrorToBePrintedOnce(fuzzTest);
 	});
 
 	it("Jest: Test with FRIENDLY command; Done callback", () => {

--- a/tests/bug-detectors/general/fuzz.js
+++ b/tests/bug-detectors/general/fuzz.js
@@ -56,7 +56,7 @@ module.exports.CallOriginalEvilDoneCallbackWithTryCatch = function (
 	try {
 		child_process.execSync(evilCommand);
 	} catch (e) {
-		console.log("error caught");
+		console.error("error caught");
 	}
 	done();
 };
@@ -76,7 +76,7 @@ module.exports.CallOriginalEvilDoneCallbackWithTimeoutWithTryCatch = function (
 		try {
 			child_process.execSync(evilCommand);
 		} catch (e) {
-			console.log("error caught");
+			console.error("error caught");
 		}
 		done();
 	}, 100);

--- a/tests/bug-detectors/prototype-pollution.test.js
+++ b/tests/bug-detectors/prototype-pollution.test.js
@@ -34,7 +34,7 @@ describe("Prototype Pollution", () => {
 		expect(() => {
 			fuzzTest.execute();
 		}).toThrowError(FuzzingExitCode);
-		expect(fuzzTest.stdout).toContain("Prototype Pollution");
+		expect(fuzzTest.stderr).toContain("Prototype Pollution");
 	});
 
 	it("{} Pollution using square braces", () => {
@@ -47,7 +47,7 @@ describe("Prototype Pollution", () => {
 		expect(() => {
 			fuzzTest.execute();
 		}).toThrowError(FuzzingExitCode);
-		expect(fuzzTest.stdout).toContain("Prototype Pollution");
+		expect(fuzzTest.stderr).toContain("Prototype Pollution");
 	});
 
 	it("[] Pollution", () => {
@@ -60,7 +60,7 @@ describe("Prototype Pollution", () => {
 		expect(() => {
 			fuzzTest.execute();
 		}).toThrowError(FuzzingExitCode);
-		expect(fuzzTest.stdout).toContain("Prototype Pollution");
+		expect(fuzzTest.stderr).toContain("Prototype Pollution");
 	});
 
 	it("Function Pollution", () => {
@@ -73,7 +73,7 @@ describe("Prototype Pollution", () => {
 		expect(() => {
 			fuzzTest.execute();
 		}).toThrowError(FuzzingExitCode);
-		expect(fuzzTest.stdout).toContain(
+		expect(fuzzTest.stderr).toContain(
 			"Prototype Pollution: Prototype of Function changed",
 		);
 	});
@@ -88,7 +88,7 @@ describe("Prototype Pollution", () => {
 		expect(() => {
 			fuzzTest.execute();
 		}).toThrowError(FuzzingExitCode);
-		expect(fuzzTest.stdout).toContain(
+		expect(fuzzTest.stderr).toContain(
 			"Prototype Pollution: Prototype of String changed",
 		);
 	});
@@ -103,7 +103,7 @@ describe("Prototype Pollution", () => {
 		expect(() => {
 			fuzzTest.execute();
 		}).toThrowError(FuzzingExitCode);
-		expect(fuzzTest.stdout).toContain(
+		expect(fuzzTest.stderr).toContain(
 			"Prototype Pollution: Prototype of Number changed",
 		);
 	});
@@ -118,7 +118,7 @@ describe("Prototype Pollution", () => {
 		expect(() => {
 			fuzzTest.execute();
 		}).toThrowError(FuzzingExitCode);
-		expect(fuzzTest.stdout).toContain(
+		expect(fuzzTest.stderr).toContain(
 			"Prototype Pollution: Prototype of Boolean changed",
 		);
 	});
@@ -136,7 +136,7 @@ describe("Prototype Pollution", () => {
 		expect(() => {
 			fuzzTest.execute();
 		}).toThrowError(FuzzingExitCode);
-		expect(fuzzTest.stdout).toContain(
+		expect(fuzzTest.stderr).toContain(
 			"Prototype Pollution: a.__proto__ value is ",
 		);
 	});
@@ -154,7 +154,7 @@ describe("Prototype Pollution", () => {
 		expect(() => {
 			fuzzTest.execute();
 		}).toThrowError(FuzzingExitCode);
-		expect(fuzzTest.stdout).toContain("Prototype Pollution: a.__proto__");
+		expect(fuzzTest.stderr).toContain("Prototype Pollution: a.__proto__");
 	});
 
 	it("Test no instrumentation and polluting __proto__ of a class", () => {
@@ -180,7 +180,7 @@ describe("Prototype Pollution", () => {
 		expect(() => {
 			fuzzTest.execute();
 		}).toThrowError(FuzzingExitCode);
-		expect(fuzzTest.stdout).toContain("Prototype Pollution");
+		expect(fuzzTest.stderr).toContain("Prototype Pollution");
 	});
 
 	it("Instrumentation on with excluded exact match", () => {
@@ -206,7 +206,7 @@ describe("Prototype Pollution", () => {
 		expect(() => {
 			fuzzTest.execute();
 		}).toThrowError(FuzzingExitCode);
-		expect(fuzzTest.stdout).toContain("Prototype Pollution");
+		expect(fuzzTest.stderr).toContain("Prototype Pollution");
 	});
 
 	it("Detect deleted toString() of {}", () => {
@@ -219,7 +219,7 @@ describe("Prototype Pollution", () => {
 		expect(() => {
 			fuzzTest.execute();
 		}).toThrowError(FuzzingExitCode);
-		expect(fuzzTest.stdout).toContain("Prototype Pollution");
+		expect(fuzzTest.stderr).toContain("Prototype Pollution");
 	});
 
 	it("Two-stage prototype pollution with object creation", () => {
@@ -235,7 +235,7 @@ describe("Prototype Pollution", () => {
 		expect(() => {
 			fuzzTest.execute();
 		}).toThrowError(FuzzingExitCode);
-		expect(fuzzTest.stdout).toContain("Prototype Pollution");
+		expect(fuzzTest.stderr).toContain("Prototype Pollution");
 	});
 
 	it("Async assignment instrumentation", () => {
@@ -250,7 +250,7 @@ describe("Prototype Pollution", () => {
 		expect(() => {
 			fuzzTest.execute();
 		}).toThrowError(FuzzingExitCode);
-		expect(fuzzTest.stdout).toContain("Prototype Pollution");
+		expect(fuzzTest.stderr).toContain("Prototype Pollution");
 	});
 
 	it("Async variable declaration instrumentation", () => {
@@ -265,7 +265,7 @@ describe("Prototype Pollution", () => {
 		expect(() => {
 			fuzzTest.execute();
 		}).toThrowError(FuzzingExitCode);
-		expect(fuzzTest.stdout).toContain("Prototype Pollution");
+		expect(fuzzTest.stderr).toContain("Prototype Pollution");
 	});
 
 	it("Equal assignments should be instrumented", () => {
@@ -281,7 +281,7 @@ describe("Prototype Pollution", () => {
 		expect(() => {
 			fuzzTest.execute();
 		}).toThrowError(FuzzingExitCode);
-		expect(fuzzTest.stdout).toContain("Prototype Pollution");
+		expect(fuzzTest.stderr).toContain("Prototype Pollution");
 	});
 
 	it("Equal variable declarations should be instrumented", () => {
@@ -297,7 +297,7 @@ describe("Prototype Pollution", () => {
 		expect(() => {
 			fuzzTest.execute();
 		}).toThrowError(FuzzingExitCode);
-		expect(fuzzTest.stdout).toContain("Prototype Pollution");
+		expect(fuzzTest.stderr).toContain("Prototype Pollution");
 	});
 
 	// Challenge to the future developer: make this test pass!
@@ -314,7 +314,7 @@ describe("Prototype Pollution", () => {
 	// 	expect(() => {
 	// 		fuzzTest.execute();
 	// 	}).toThrowError(FuzzingExitCode);
-	// 	expect(fuzzTest.stdout).toContain("Prototype Pollution");
+	// 	expect(fuzzTest.stderr).toContain("Prototype Pollution");
 	// });
 });
 
@@ -466,7 +466,6 @@ describe("Prototype Pollution instrumentation correctness tests", () => {
 			.dryRun(false)
 			.fuzzEntryPoint("LambdaVariableDeclaration")
 			.fuzzFile(fuzzFile)
-			.verbose(true)
 			.build();
 		fuzzTest.execute();
 	});

--- a/tests/bug-detectors/prototype-pollution/fuzz.js
+++ b/tests/bug-detectors/prototype-pollution/fuzz.js
@@ -34,7 +34,9 @@ module.exports.FunctionObjectPollution = function (data) {
 		/* empty */
 	};
 	Function.__proto__.polluted = () => {
-		console.log("This is printed when the prototype of Function is polluted.");
+		console.error(
+			"This is printed when the prototype of Function is polluted.",
+		);
 	};
 	const c = () => {
 		/* empty */
@@ -79,7 +81,7 @@ module.exports.ChangedToString = function (data) {
 	a.__proto__.toString = () => {
 		return "test";
 	};
-	console.log(Object.getPrototypeOf(a));
+	console.error(Object.getPrototypeOf(a));
 };
 
 module.exports.DeletedToString = function (data) {
@@ -97,7 +99,7 @@ module.exports.TwoStagePollutionWithObjectCreation = function (data) {
 	const b = a["__proto__"];
 	b.polluted = true;
 	const c = new A(); // If we make a new object, PP will be detected.
-	console.log(c.polluted);
+	console.error(c.polluted);
 };
 
 // Current instrumentation does not detect this. This test is currently unused.

--- a/tests/bug-detectors/prototype-pollution/tests.fuzz.js
+++ b/tests/bug-detectors/prototype-pollution/tests.fuzz.js
@@ -23,7 +23,7 @@ describe("Prototype Pollution Jest tests", () => {
 	it.fuzz("Assignments", (data) => {
 		let a;
 		a = { __proto__: { a: 10 } };
-		console.log(a.__proto__);
+		console.error(a.__proto__);
 	});
 
 	it.fuzz("Variable declarations", (data) => {

--- a/tests/return_values/return_values.test.js
+++ b/tests/return_values/return_values.test.js
@@ -68,7 +68,6 @@ function executeFuzzTest(sync, verbose, dir) {
 		.runs(5000)
 		.dir(dir)
 		.sync(sync)
-		.verbose(verbose)
 		.expectedErrors("Error")
 		.build();
 	fuzzTest.execute();

--- a/tests/signal_handlers/SIGINT/fuzz.js
+++ b/tests/signal_handlers/SIGINT/fuzz.js
@@ -18,11 +18,11 @@ let i = 0;
 
 module.exports.SIGINT_SYNC = (data) => {
 	if (i === 1000) {
-		console.log("kill with signal");
+		console.error("kill with signal");
 		process.kill(process.pid, "SIGINT");
 	}
 	if (i > 1000) {
-		console.log("Signal has not stopped the fuzzing process");
+		console.error("Signal has not stopped the fuzzing process");
 	}
 	i++;
 };
@@ -31,7 +31,7 @@ module.exports.SIGINT_ASYNC = (data) => {
 	// Raising SIGINT in async mode does not stop the fuzzer directly,
 	// as the event is handled asynchronously in the event loop.
 	if (i === 1000) {
-		console.log("kill with signal");
+		console.error("kill with signal");
 		process.kill(process.pid, "SIGINT");
 	}
 	i++;

--- a/tests/signal_handlers/SIGSEGV/fuzz.js
+++ b/tests/signal_handlers/SIGSEGV/fuzz.js
@@ -18,11 +18,11 @@ let i = 0;
 
 module.exports.SIGSEGV_SYNC = (data) => {
 	if (i === 1000) {
-		console.log("kill with signal");
+		console.error("kill with signal");
 		process.kill(process.pid, "SIGSEGV");
 	}
 	if (i > 1000) {
-		console.log("Signal has not stopped the fuzzing process");
+		console.error("Signal has not stopped the fuzzing process");
 	}
 	i++;
 };
@@ -31,7 +31,7 @@ module.exports.SIGSEGV_ASYNC = (data) => {
 	// Raising SIGSEGV in async mode does not stop the fuzzer directly,
 	// as the event is handled asynchronously in the event loop.
 	if (i === 1000) {
-		console.log("kill with signal");
+		console.error("kill with signal");
 		process.kill(process.pid, "SIGSEGV");
 	}
 	i++;

--- a/tests/signal_handlers/signal_handlers.test.js
+++ b/tests/signal_handlers/signal_handlers.test.js
@@ -30,8 +30,7 @@ describe("SIGINT handlers", () => {
 		fuzzTestBuilder = new FuzzTestBuilder()
 			.runs(20000)
 			.dir(path.join(__dirname, "SIGINT"))
-			.coverage(true)
-			.verbose(true);
+			.coverage(true);
 	});
 
 	describe("in standalone fuzzing mode", () => {
@@ -83,8 +82,7 @@ describe("SIGSEGV handlers", () => {
 		fuzzTestBuilder = new FuzzTestBuilder()
 			.runs(20000)
 			.dir(path.join(__dirname, "SIGSEGV"))
-			.coverage(true)
-			.verbose(true);
+			.coverage(true);
 	});
 
 	describe("in standalone fuzzing mode", () => {
@@ -133,26 +131,27 @@ describe("SIGSEGV handlers", () => {
 });
 
 function assertSignalMessagesLogged(fuzzTest) {
-	expect(fuzzTest.stdout).toContain("kill with signal");
+	expect(fuzzTest.stderr).toContain("kill with signal");
 
 	// We asked for a coverage report. Here we only look for the universal part of its header.
+	// Jest prints to stdout.
 	expect(fuzzTest.stdout).toContain(
 		"| % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s",
 	);
 
 	// Count how many times "Signal has not stopped the fuzzing process" has been printed.
-	const matches = fuzzTest.stdout.match(
+	const matches = fuzzTest.stderr.match(
 		/Signal has not stopped the fuzzing process/g,
 	);
 	const signalNotStoppedMessageCount = matches ? matches.length : 0;
 
 	// In the GH pipeline the process does not immediately stop after receiving a signal.
-	// So we check that the messas has been printed not more than 1k times out of 19k (the signal
+	// So we check that the message has been printed not more than 1k times out of 19k (the signal
 	// is sent after 1k runs, with 20k runs in total).
 	expect(signalNotStoppedMessageCount).toBeLessThan(1000);
 }
 
 function assertErrorAndCrashFileLogged(fuzzTest, errorMessage) {
-	expect(fuzzTest.stdout).toContain(errorMessage);
+	expect(fuzzTest.stderr).toContain(errorMessage);
 	expect(fuzzTest.stderr).toContain("Test unit written to ");
 }


### PR DESCRIPTION
Internal messages should not clutter up the normal output and piped to `stderr` instead.