### PR TITLE
bugfix: prevent TypeError in the bug detectors

### DIFF
--- a/packages/bug-detectors/internal/command-injection.ts
+++ b/packages/bug-detectors/internal/command-injection.ts
@@ -45,6 +45,9 @@ for (const functionName of functionNames) {
 		// - the command/file path to execute in execFile/execFileSync
 		// - the module path to fork in fork
 		const firstArgument = params[0] as string;
+		if (typeof firstArgument !== "string") {
+			return;
+		}
 		if (firstArgument.includes(goal)) {
 			reportFinding(
 				`Command Injection in ${functionName}(): called with '${firstArgument}'`,

--- a/tests/bug-detectors/command-injection.test.js
+++ b/tests/bug-detectors/command-injection.test.js
@@ -171,3 +171,19 @@ describe("Command injection", () => {
 		expect(fs.existsSync(friendlyFilePath)).toBeTruthy();
 	});
 });
+
+describe("Invalid arguments", () => {
+	const bugDetectorDirectory = path.join(__dirname, "command-injection");
+	const errorMessage = /TypeError: The ".*" argument must be of type string./;
+
+	it("invalid args to exec", () => {
+		const fuzzTest = new FuzzTestBuilder()
+			.runs(0)
+			.sync(false)
+			.fuzzEntryPoint("execInvalid")
+			.dir(bugDetectorDirectory)
+			.build();
+		expect(() => fuzzTest.execute()).toThrow();
+		expect(fuzzTest.stderr).toMatch(errorMessage);
+	});
+});

--- a/tests/bug-detectors/command-injection/fuzz.js
+++ b/tests/bug-detectors/command-injection/fuzz.js
@@ -92,3 +92,7 @@ module.exports.forkEVIL = function (data) {
 module.exports.forkFRIENDLY = function (data) {
 	child_process.fork("makeFRIENDLY.js");
 };
+
+module.exports.execInvalid = async function (data) {
+	child_process.exec(0);
+};

--- a/tests/bug-detectors/path-traversal.test.js
+++ b/tests/bug-detectors/path-traversal.test.js
@@ -186,3 +186,33 @@ describe("Path Traversal", () => {
 		fuzzTest.execute();
 	});
 });
+
+describe("Path Traversal invalid input", () => {
+	const bugDetectorDirectory = path.join(__dirname, "path-traversal");
+	const errorMessage =
+		/TypeError: The ".*" argument must be of type string or an instance of Buffer or URL./;
+
+	it("Invalid args to open", () => {
+		const fuzzTest = new FuzzTestBuilder()
+			.runs(0)
+			.sync(true)
+			.fuzzEntryPoint("invalidArgsToOpen")
+			.dir(bugDetectorDirectory)
+			.build();
+		expect(() => fuzzTest.execute()).toThrow();
+		expect(fuzzTest.stderr).toMatch(errorMessage);
+	});
+
+	it("Invalid first arg to cp", () => {
+		const fuzzTest = new FuzzTestBuilder()
+			.runs(0)
+			.sync(true)
+			.fuzzEntryPoint("invalidArgsToCp")
+			.dir(bugDetectorDirectory)
+			.build();
+		expect(() => fuzzTest.execute()).toThrow();
+		// 'TypeError: The "src" argument must be of type string or an instance of Buffer or URL.',
+		// however the string "src" may vary from system to system, so a regexp is better
+		expect(fuzzTest.stderr).toMatch(errorMessage);
+	});
+});

--- a/tests/bug-detectors/path-traversal/fuzz.js
+++ b/tests/bug-detectors/path-traversal/fuzz.js
@@ -100,3 +100,11 @@ module.exports.PathTraversalJoinEvilAsync = makeFnCalledOnce(async (data) => {
 module.exports.PathTraversalJoinSafeAsync = makeFnCalledOnce(async (data) => {
 	path.join(safe_path, "SAFE");
 });
+
+module.exports.invalidArgsToOpen = makeFnCalledOnce((data) => {
+	fs.openSync(0);
+});
+
+module.exports.invalidArgsToCp = makeFnCalledOnce((data) => {
+	fs.cp(0, 0, () => {});
+});


### PR DESCRIPTION
The path-traversal and command-injection bug detectors now don't throw a TypeError upon receiving arguments of the wrong type. Instead, they forward their arguments as-is to their hooked functions that can give meaningful errors.
This also extends guidance and detection support to arguments whose type is Buffer and URL for some functions hooked by the path-traversal bug detector.