### PR TITLE
Jest support: List fuzz test names

### DIFF
--- a/packages/jest-runner/fuzz.ts
+++ b/packages/jest-runner/fuzz.ts
@@ -49,6 +49,26 @@ export const skip: (globals: Global.Global) => FuzzTest =
 
 export type JestTestMode = "skip" | "only" | "standard";
 
+function printTestNameIfRequested(testStatePath: string[]) {
+	const full_name: string = testStatePath.join(" ");
+	if (process.env.JAZZER_LIST_FUZZTEST_NAMES) {
+		if (
+			process.env.JAZZER_LIST_FUZZTEST_NAMES_PATTERN == undefined ||
+			full_name.match(process.env.JAZZER_LIST_FUZZTEST_NAMES_PATTERN)
+		) {
+			if (process.env.JAZZER_LIST_FUZZTEST_NAMES == "short") {
+				const short_name: string = testStatePath.pop() || "";
+				console.log(short_name);
+			} else if (process.env.JAZZER_LIST_FUZZTEST_NAMES == "split") {
+				const split_name: string = testStatePath.join(" / ");
+				console.log(split_name);
+			} else {
+				console.log(full_name);
+			}
+		}
+	}
+}
+
 export function fuzz(
 	globals: Global.Global,
 	testFile: string,
@@ -72,6 +92,9 @@ export function fuzz(
 		// only the requested tests are executed.
 		const testStatePath = currentTestStatePath(toTestName(name), state);
 		const testNamePattern = originalTestNamePattern();
+
+		printTestNameIfRequested(testStatePath);
+
 		const skip =
 			testStatePath !== undefined &&
 			testNamePattern != undefined &&

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -46,6 +46,8 @@ class FuzzTest {
 		seed,
 		sync,
 		verbose,
+		listFuzzTestNames,
+		listFuzzTestNamesPattern,
 		coverage,
 		expectedErrors,
 		asJson,
@@ -68,6 +70,8 @@ class FuzzTest {
 		this.seed = seed;
 		this.sync = sync;
 		this.verbose = verbose;
+		this.listFuzzTestNames = listFuzzTestNames;
+		this.listFuzzTestNamesPattern = listFuzzTestNamesPattern;
 		this.coverage = coverage;
 		this.expectedErrors = expectedErrors;
 		this.asJson = asJson;
@@ -170,8 +174,17 @@ class FuzzTest {
 			"--no-colors",
 			this.asJson ? "--json" : "",
 			this.coverage ? "--coverage" : "",
+			this.listFuzzTestNames ? "--reporters=" : "",
 		];
-		this.runTest(cmd, options, { ...process.env });
+		let env = { ...process.env };
+		if (this.listFuzzTestNames) {
+			env.JAZZER_LIST_FUZZTEST_NAMES = "1";
+		}
+		if (this.listFuzzTestNamesPattern) {
+			env.JAZZER_LIST_FUZZTEST_NAMES_PATTERN = this.listFuzzTestNamesPattern;
+		}
+
+		this.runTest(cmd, options, env);
 	}
 
 	runTest(cmd, options, env) {
@@ -204,6 +217,8 @@ class FuzzTestBuilder {
 	_dryRun = undefined;
 	_runs = undefined;
 	_verbose = false;
+	_listFuzzTestNames = false;
+	_listFuzzTestNamesPattern = undefined;
 	_fuzzEntryPoint = "";
 	_dir = "";
 	_fuzzFile = "fuzz";
@@ -245,6 +260,27 @@ class FuzzTestBuilder {
 	 */
 	verbose(verbose) {
 		this._verbose = verbose === undefined ? true : verbose;
+		return this;
+	}
+
+	/**
+	 * @param {boolean} listFuzzTestNames - whether to list all fuzz test names on the console. True by
+	 * default.
+	 */
+	listFuzzTestNames(listFuzzTestNames) {
+		this._listFuzzTestNames =
+			listFuzzTestNames === undefined ? true : listFuzzTestNames;
+		if (this._listFuzzTestNames) {
+			this.jestTestName("__NOT_AN_ACTUAL_TESTNAME__");
+		}
+		return this;
+	}
+
+	/**
+	 * @param {boolean} listFuzzTestNamesPattern - pattern to filter the list of all fuzz test names.
+	 */
+	listFuzzTestNamesPattern(listFuzzTestNamesPattern) {
+		this._listFuzzTestNamesPattern = listFuzzTestNamesPattern;
 		return this;
 	}
 
@@ -424,6 +460,8 @@ class FuzzTestBuilder {
 			this._seed,
 			this._sync,
 			this._verbose,
+			this._listFuzzTestNames,
+			this._listFuzzTestNamesPattern,
 			this._coverage,
 			this._expectedErrors,
 			this._asJson,

--- a/tests/jest_integration/integration.test.js
+++ b/tests/jest_integration/integration.test.js
@@ -354,6 +354,66 @@ describe("Jest integration", () => {
 			});
 		});
 	});
+
+	describe("List all fuzz tests", () => {
+		const listFuzzTestNamesTestBuilder = new FuzzTestBuilder()
+			.dir(projectDir)
+			.listFuzzTestNames()
+			.jestTestFile(jestTestFile + ".js");
+
+		it("lists fuzz tests", () => {
+			const listFuzzTestNames = listFuzzTestNamesTestBuilder.build();
+
+			listFuzzTestNames.execute();
+
+			expect(listFuzzTestNames.stdout).toContain(
+				"Jest Integration execute sync test",
+			);
+			expect(listFuzzTestNames.stdout).toContain(
+				"Run mode skip and standard standard test",
+			);
+		});
+
+		it("filters fuzz tests by name", () => {
+			const listFuzzTestNames = listFuzzTestNamesTestBuilder
+				.listFuzzTestNamesPattern("sync test")
+				.build();
+
+			listFuzzTestNames.execute();
+
+			expect(listFuzzTestNames.stdout).toContain(
+				"Jest Integration execute sync test",
+			);
+			expect(listFuzzTestNames.stdout).not.toContain(
+				"Run mode skip and standard standard test",
+			);
+		});
+
+		it("filters fuzz tests by describe name", () => {
+			const listFuzzTestNames = listFuzzTestNamesTestBuilder
+				.listFuzzTestNamesPattern("Jest")
+				.build();
+
+			listFuzzTestNames.execute();
+
+			expect(listFuzzTestNames.stdout).toContain(
+				"Jest Integration execute sync test",
+			);
+			expect(listFuzzTestNames.stdout).not.toContain(
+				"Run mode skip and standard standard test",
+			);
+		});
+
+		it("prints nothing else on stdout", () => {
+			const listFuzzTestNames = listFuzzTestNamesTestBuilder
+				.listFuzzTestNamesPattern("__NOT_AN_ACTUAL_TESTNAME__")
+				.build();
+
+			listFuzzTestNames.execute();
+
+			expect(listFuzzTestNames.stdout).toBe("");
+		});
+	});
 });
 
 // Deflake the "timeout after N seconds" test to be more tolerant to small variations of N (+-1).


### PR DESCRIPTION
Lists fuzz test names if `JAZZER_LIST_FUZZTEST_NAMES` is set. Futhermore, will filter the list by regex if `JAZZER_LIST_FUZZTEST_NAMES_PATTERN` is set.