### PR TITLE
use of const in loop of StartLibFuzzer

### DIFF
--- a/packages/fuzzer/utils.cpp
+++ b/packages/fuzzer/utils.cpp
@@ -20,8 +20,9 @@
 
 .
 // ************Important************
-// The impact on performance of using const here is little bit more proven as compare to previously used code and also good intent/clearity of code.
+// The impact on performance of using const here is little bit more proven as compare to previously used code and also good intent/clearity of codes.
 // It helps convey that the loop is intended to read, but not modify, the elements of the vector. 
+
 
 void StartLibFuzzer(const std::vector<std::string> &args, fuzzer::UserCallback fuzzCallback) {
   std::vector<char *> fuzzer_arg_pointers;


### PR DESCRIPTION
there are slight differences in the way they achieve the same goal, which is to convert a vector of C++ strings (std::vector<std::string>) into an array of C-style strings (char**) and pass it to the fuzzer::FuzzerDriver function