### PR TITLE
feat: add remote code execution sanitizer

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -25,3 +25,7 @@ example
 *.ts
 !*.d.ts
 *test*.d.ts
+
+# Exclude native fuzzer sources
+packages/fuzzer/**/*.cpp
+packages/fuzzer/**/*.h

--- a/docs/fuzz-settings.md
+++ b/docs/fuzz-settings.md
@@ -213,12 +213,13 @@ option.
 
 ## Bug Detectors
 
-Bug detectors are one of the key features when fuzzing memory-safe languages. In
-Jazzer.js, they can detect some of the most common vulnerabilities in JavaScript
-code. Built-in bug detectors are enabled by default, but can be disabled by
-adding the `--disable_bug_detectors=<pattern>` flag to the project
-configuration. To disable all built-in bug detectors, add
-`--disable_bug_detectors='.*'` to the project configuration.
+Bug detectors (sometimes also called sanitizers) are one of the key features
+when fuzzing memory-safe languages. In Jazzer.js, they can detect some of the
+most common vulnerabilities in JavaScript code. Built-in bug detectors are
+enabled by default, but can be disabled by adding the
+`--disable_bug_detectors=<pattern>` flag to the project configuration. To
+disable all built-in bug detectors, add `--disable_bug_detectors='.*'` to the
+project configuration.
 
 ### Command Injection
 
@@ -229,6 +230,19 @@ _Disable with:_ `--disable_bug_detectors=command-injection`, or when using Jest:
 
 ```json
 { "disableBugDetectors": ["command-injection"] }
+```
+
+### Remote Code Execution
+
+Hooks the `eval` and `Function` functions and reports a finding if the fuzzer
+was able to pass a special string to `eval` and to the function body of
+`Function`.
+
+_Disable with:_ `--disable_bug_detectors=remote-code-execution`, or when using
+Jest:
+
+```json
+{ "disableBugDetectors": ["remote-code-execution"] }
 ```
 
 ### Path Traversal

--- a/fuzztests/FuzzedDataProvider.fuzz.js
+++ b/fuzztests/FuzzedDataProvider.fuzz.js
@@ -33,7 +33,7 @@ describe("FuzzedDataProvider", () => {
 				.filter((m) => provider[m].length === 0);
 
 			let usedMethods = "";
-			while (provider.remainingBytes > 0) {
+			while (provider.remainingBytes > 0 && methodNames.length > 0) {
 				const methodName = provider.pickValue(methodNames);
 				provider[methodName].call(provider);
 				usedMethods += methodName;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10054,12 +10054,6 @@
 			"name": "@jazzer.js/hooking",
 			"version": "2.0.0",
 			"license": "Apache-2.0",
-			"dependencies": {
-				"@babel/core": "^7.23.2"
-			},
-			"devDependencies": {
-				"@types/babel__core": "^7.20.2"
-			},
 			"engines": {
 				"node": ">= 14.0.0",
 				"npm": ">= 7.0.0"
@@ -10841,11 +10835,7 @@
 			}
 		},
 		"@jazzer.js/hooking": {
-			"version": "file:packages/hooking",
-			"requires": {
-				"@babel/core": "^7.23.2",
-				"@types/babel__core": "^7.20.2"
-			}
+			"version": "file:packages/hooking"
 		},
 		"@jazzer.js/instrumentor": {
 			"version": "file:packages/instrumentor",

--- a/packages/bug-detectors/internal/remote-code-execution.ts
+++ b/packages/bug-detectors/internal/remote-code-execution.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+	guideTowardsContainment,
+	reportAndThrowFinding,
+} from "@jazzer.js/core";
+import { callSiteId, registerBeforeHook } from "@jazzer.js/hooking";
+
+const targetString = "jaz_zer";
+
+registerBeforeHook(
+	"eval",
+	"",
+	false,
+	function beforeEvalHook(_thisPtr: unknown, params: string[], hookId: number) {
+		const code = params[0];
+		// This check will prevent runtime TypeErrors should the user decide to call Function with
+		// non-string arguments.
+		// noinspection SuspiciousTypeOfGuard
+		if (typeof code === "string" && code.includes(targetString)) {
+			reportAndThrowFinding(
+				`Remote Code Execution using eval:\n        '${code}'`,
+			);
+		}
+
+		// Since we do not hook eval using the hooking framework, we have to recompute the
+		// call site ID on every call to eval. This shouldn't be an issue, because eval is
+		// considered evil and should not be called too often, or even better -- not at all!
+		guideTowardsContainment(code, targetString, hookId);
+	},
+);
+
+registerBeforeHook(
+	"Function",
+	"",
+	false,
+	function beforeFunctionHook(
+		_thisPtr: unknown,
+		params: string[],
+		hookId: number,
+	) {
+		if (params.length > 0) {
+			const functionBody = params[params.length - 1];
+
+			// noinspection SuspiciousTypeOfGuard
+			if (typeof functionBody === "string") {
+				if (functionBody.includes(targetString)) {
+					reportAndThrowFinding(
+						`Remote Code Execution using Function:\n        '${functionBody}'`,
+					);
+				}
+				guideTowardsContainment(functionBody, targetString, hookId);
+			}
+		}
+	},
+);

--- a/packages/core/core.ts
+++ b/packages/core/core.ts
@@ -115,7 +115,7 @@ export async function initFuzzing(options: Options): Promise<Instrumentor> {
 	await Promise.all(options.customHooks.map(ensureFilepath).map(importModule));
 
 	await hooking.hookManager.finalizeHooks(
-		getJazzerJsGlobal<vm.Context>("vmContext"),
+		getJazzerJsGlobal<vm.Context>("vmContext") ?? globalThis,
 	);
 
 	return instrumentor;

--- a/packages/core/core.ts
+++ b/packages/core/core.ts
@@ -16,6 +16,7 @@
 
 import * as fs from "fs";
 import path from "path";
+import * as vm from "vm";
 
 import * as libCoverage from "istanbul-lib-coverage";
 import * as libReport from "istanbul-lib-report";
@@ -40,7 +41,7 @@ import {
 	printFinding,
 	reportFinding,
 } from "./finding";
-import { jazzerJs } from "./globals";
+import { getJazzerJsGlobal, jazzerJs } from "./globals";
 import { buildFuzzerOption, Options } from "./options";
 import { ensureFilepath, importModule } from "./utils";
 
@@ -113,7 +114,9 @@ export async function initFuzzing(options: Options): Promise<Instrumentor> {
 
 	await Promise.all(options.customHooks.map(ensureFilepath).map(importModule));
 
-	await hooking.hookManager.finalizeHooks();
+	await hooking.hookManager.finalizeHooks(
+		getJazzerJsGlobal<vm.Context>("vmContext"),
+	);
 
 	return instrumentor;
 }

--- a/packages/hooking/package.json
+++ b/packages/hooking/package.json
@@ -15,12 +15,6 @@
 	},
 	"main": "dist/index.js",
 	"types": "dist/index.d.js",
-	"dependencies": {
-		"@babel/core": "^7.23.2"
-	},
-	"devDependencies": {
-		"@types/babel__core": "^7.20.2"
-	},
 	"engines": {
 		"node": ">= 14.0.0",
 		"npm": ">= 7.0.0"

--- a/tests/bug-detectors/remote-code-execution.test.js
+++ b/tests/bug-detectors/remote-code-execution.test.js
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const path = require("path");
+
+const {
+	FuzzTestBuilder,
+	FuzzingExitCode,
+	JestRegressionExitCode,
+} = require("../helpers.js");
+
+const bugDetectorDirectory = path.join(__dirname, "remote-code-execution");
+
+const findingMessage = "Remote Code Execution using";
+const okMessage = "can be called just fine";
+let fuzzTestBuilder;
+
+beforeEach(() => {
+	fuzzTestBuilder = new FuzzTestBuilder()
+		.runs(0)
+		.dir(bugDetectorDirectory)
+		.sync(true);
+});
+
+describe("CLI", () => {
+	describe("eval ()", () => {
+		it("Invocation without error", () => {
+			const fuzzTest = fuzzTestBuilder
+				.fuzzEntryPoint("invocationWithoutError")
+				.build()
+				.execute();
+			expect(fuzzTest.stdout).toContain(okMessage);
+		});
+
+		it("Direct invocation", () => {
+			const fuzzTest = fuzzTestBuilder
+				.fuzzEntryPoint("directInvocation")
+				.sync(true)
+				.build();
+			expect(() => {
+				fuzzTest.execute();
+			}).toThrowError(FuzzingExitCode);
+			expect(fuzzTest.stderr).toContain(findingMessage);
+		});
+
+		it("Indirect invocation", () => {
+			const fuzzTest = fuzzTestBuilder
+				.fuzzEntryPoint("indirectInvocation")
+				.sync(true)
+				.build();
+			expect(() => {
+				fuzzTest.execute();
+			}).toThrowError(FuzzingExitCode);
+			expect(fuzzTest.stderr).toContain(findingMessage);
+		});
+
+		it("Indirect invocation using comma operator", () => {
+			const fuzzTest = fuzzTestBuilder
+				.fuzzEntryPoint("indirectInvocationUsingCommaOperator")
+				.sync(true)
+				.build();
+			expect(() => {
+				fuzzTest.execute();
+			}).toThrowError(FuzzingExitCode);
+			expect(fuzzTest.stderr).toContain(findingMessage);
+		});
+
+		it("Indirect invocation through optional chaining", () => {
+			const fuzzTest = fuzzTestBuilder
+				.fuzzEntryPoint("indirectInvocationThroughOptionalChaining")
+				.sync(true)
+				.build();
+			expect(() => {
+				fuzzTest.execute();
+			}).toThrowError(FuzzingExitCode);
+			expect(fuzzTest.stderr).toContain(findingMessage);
+		});
+	});
+
+	describe("Function constructor", () => {
+		it("Invocation without error, without explicit constructor", () => {
+			const fuzzTest = fuzzTestBuilder
+				.fuzzEntryPoint("functionNoErrorNoConstructor")
+				.sync(true)
+				.build()
+				.execute();
+			expect(fuzzTest.stdout).toContain(okMessage);
+		});
+
+		it("Invocation without error", () => {
+			const fuzzTest = fuzzTestBuilder
+				.fuzzEntryPoint("functionNoErrorWithConstructor")
+				.sync(true)
+				.build()
+				.execute();
+			expect(fuzzTest.stdout).toContain(okMessage);
+		});
+
+		it("Direct invocation", () => {
+			const fuzzTest = fuzzTestBuilder
+				.fuzzEntryPoint("functionError")
+				.sync(true)
+				.build();
+			expect(() => {
+				fuzzTest.execute();
+			}).toThrowError(FuzzingExitCode);
+			expect(fuzzTest.stderr).toContain(findingMessage);
+		});
+
+		it("Direct invocation using new", () => {
+			const fuzzTest = fuzzTestBuilder
+				.fuzzEntryPoint("functionErrorNew")
+				.sync(true)
+				.build();
+			expect(() => {
+				fuzzTest.execute();
+			}).toThrowError(FuzzingExitCode);
+			expect(fuzzTest.stderr).toContain(findingMessage);
+		});
+
+		it("Target string in variable name - no error", () => {
+			const fuzzTest = fuzzTestBuilder
+				.fuzzEntryPoint("functionWithArgNoError")
+				.sync(true)
+				.build()
+				.execute();
+			expect(fuzzTest.stdout).toContain(okMessage);
+		});
+
+		it("With error - target string in last arg", () => {
+			const fuzzTest = fuzzTestBuilder
+				.fuzzEntryPoint("functionWithArgError")
+				.sync(true)
+				.build();
+			expect(() => {
+				fuzzTest.execute();
+			}).toThrowError(FuzzingExitCode);
+			expect(fuzzTest.stderr).toContain(findingMessage);
+		});
+	});
+});
+
+describe("Jest", () => {
+	describe("eval", () => {
+		it("Direct invocation", () => {
+			const fuzzTest = fuzzTestBuilder
+				.dryRun(false)
+				.jestTestFile("tests.fuzz.js")
+				.jestTestName("eval Direct invocation$")
+				.build();
+			expect(() => {
+				fuzzTest.execute();
+			}).toThrowError(JestRegressionExitCode);
+			expect(fuzzTest.stderr).toContain(findingMessage);
+		});
+
+		it("Indirect invocation", () => {
+			const fuzzTest = fuzzTestBuilder
+				.dryRun(false)
+				.jestTestFile("tests.fuzz.js")
+				.jestTestName("eval Indirect invocation$")
+				.build();
+			expect(() => {
+				fuzzTest.execute();
+			}).toThrowError(JestRegressionExitCode);
+			expect(fuzzTest.stderr).toContain(findingMessage);
+		});
+
+		it("Indirect invocation using comma operator", () => {
+			const fuzzTest = fuzzTestBuilder
+				.dryRun(false)
+				.jestTestFile("tests.fuzz.js")
+				.jestTestName("eval Indirect invocation using comma operator$")
+				.build();
+			expect(() => {
+				fuzzTest.execute();
+			}).toThrowError(JestRegressionExitCode);
+			expect(fuzzTest.stderr).toContain(findingMessage);
+		});
+
+		it("Indirect invocation using optional chaining", () => {
+			const fuzzTest = fuzzTestBuilder
+				.dryRun(false)
+				.verbose(true)
+				.jestTestFile("tests.fuzz.js")
+				.jestTestName("eval Indirect invocation through optional chaining$")
+				.build();
+			expect(() => {
+				fuzzTest.execute();
+			}).toThrowError(JestRegressionExitCode);
+			expect(fuzzTest.stderr).toContain(findingMessage);
+		});
+
+		it("No error with absence of the target string", () => {
+			const fuzzTest = fuzzTestBuilder
+				.dryRun(false)
+				.jestTestFile("tests.fuzz.js")
+				.jestTestName("eval No error$")
+				.build()
+				.execute();
+			expect(fuzzTest.stdout).toContain(okMessage);
+		});
+	});
+
+	describe("Function constructor", () => {
+		it("No error", () => {
+			const fuzzTest = fuzzTestBuilder
+				.dryRun(false)
+				.jestTestFile("tests.fuzz.js")
+				.jestTestName("Function No error$")
+				.build();
+			fuzzTest.execute();
+			expect(fuzzTest.stdout).toContain(okMessage);
+		});
+
+		it("No error with constructor", () => {
+			const fuzzTest = fuzzTestBuilder
+				.dryRun(false)
+				.jestTestFile("tests.fuzz.js")
+				.jestTestName("Function No error with constructor$")
+				.build();
+			fuzzTest.execute();
+			expect(fuzzTest.stdout).toContain(okMessage);
+		});
+
+		it("With error", () => {
+			const fuzzTest = fuzzTestBuilder
+				.dryRun(false)
+				.jestTestFile("tests.fuzz.js")
+				.jestTestName("Function With error$")
+				.build();
+			expect(() => {
+				fuzzTest.execute();
+			}).toThrowError(JestRegressionExitCode);
+			expect(fuzzTest.stderr).toContain(findingMessage);
+		});
+
+		it("With error with constructor", () => {
+			const fuzzTest = fuzzTestBuilder
+				.dryRun(false)
+				.jestTestFile("tests.fuzz.js")
+				.jestTestName("Function With error with constructor$")
+				.build();
+			expect(() => {
+				fuzzTest.execute();
+			}).toThrowError(JestRegressionExitCode);
+			expect(fuzzTest.stderr).toContain(findingMessage);
+		});
+
+		it("Variable name containing target string should not throw", () => {
+			const fuzzTest = fuzzTestBuilder
+				.dryRun(false)
+				.jestTestFile("tests.fuzz.js")
+				.jestTestName("Function Target string in variable name - no error$")
+				.build()
+				.execute();
+			expect(fuzzTest.stdout).toContain(okMessage);
+		});
+
+		it("With variable, body contains target string - should throw", () => {
+			const fuzzTest = fuzzTestBuilder
+				.dryRun(false)
+				.jestTestFile("tests.fuzz.js")
+				.jestTestName("Function With error - target string in last arg$")
+				.build();
+			expect(() => {
+				fuzzTest.execute();
+			}).toThrowError(JestRegressionExitCode);
+			expect(fuzzTest.stderr).toContain(findingMessage);
+		});
+	});
+});

--- a/tests/bug-detectors/remote-code-execution/fuzz.js
+++ b/tests/bug-detectors/remote-code-execution/fuzz.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const printOkMessage = "console.log('can be called just fine')";
+
+// eval
+module.exports.invocationWithoutError = function (data) {
+	eval("const a = 10; const b = 20;" + printOkMessage);
+};
+
+module.exports.directInvocation = function (data) {
+	eval("const jaz_zer = 10;");
+};
+
+module.exports.indirectInvocation = function (data) {
+	const a = eval;
+	a("const jaz_zer = 10;");
+};
+
+module.exports.indirectInvocationUsingCommaOperator = function (data) {
+	(0, eval)("const jaz_zer = 10;");
+};
+
+module.exports.indirectInvocationThroughOptionalChaining = function (data) {
+	eval?.("const jaz_zer = 10;");
+};
+
+// Function
+module.exports.functionNoErrorNoConstructor = function (data) {
+	Function("const a = 10; const b = 20;" + printOkMessage)();
+};
+
+module.exports.functionNoErrorWithConstructor = function (data) {
+	const fn = new Function("const a = 10; const b = 20;" + printOkMessage);
+	fn();
+};
+
+module.exports.functionError = function (data) {
+	Function("const jaz_zer = 10;");
+};
+
+module.exports.functionErrorNew = function (data) {
+	new Function("const jaz_zer = 10;")();
+};
+
+module.exports.functionWithArgNoError = function (data) {
+	new Function(
+		"jaz_zer",
+		"const foo = 10; console.log('Function can be called just fine')",
+	)("_");
+};
+
+module.exports.functionWithArgError = function (data) {
+	new Function("foo", "const jaz_zer = 10;")("_");
+};

--- a/tests/bug-detectors/remote-code-execution/package.json
+++ b/tests/bug-detectors/remote-code-execution/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "jazzerjs-remote-code-execution-tests",
+	"version": "1.0.0",
+	"description": "Tests for the Remote Code Execution bug detector",
+	"scripts": {
+		"test": "jest",
+		"fuzz": "JAZZER_FUZZ=1 jest"
+	},
+	"devDependencies": {
+		"@jazzer.js/jest-runner": "file:../../packages/jest-runner",
+		"eslint-plugin-jest": "^27.1.3"
+	},
+	"jest": {
+		"projects": [
+			{
+				"testRunner": "@jazzer.js/jest-runner",
+				"displayName": {
+					"name": "Jazzer.js",
+					"color": "cyan"
+				},
+				"testMatch": [
+					"<rootDir>/**/*.fuzz.js"
+				]
+			}
+		]
+	}
+}

--- a/tests/bug-detectors/remote-code-execution/tests.fuzz.js
+++ b/tests/bug-detectors/remote-code-execution/tests.fuzz.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const tests = require("./fuzz");
+
+describe("eval", () => {
+	it.fuzz("No error", (data) => {
+		tests.invocationWithoutError(data);
+	});
+
+	it.fuzz("Direct invocation", (data) => {
+		tests.directInvocation(data);
+	});
+
+	it.fuzz("Indirect invocation", (data) => {
+		tests.indirectInvocation(data);
+	});
+
+	it.fuzz("Indirect invocation using comma operator", (data) => {
+		tests.indirectInvocationUsingCommaOperator(data);
+	});
+
+	it.fuzz("Indirect invocation through optional chaining", (data) => {
+		tests.indirectInvocationThroughOptionalChaining(data);
+	});
+});
+
+describe("Function", () => {
+	it.fuzz("No error", (data) => {
+		tests.functionNoErrorNoConstructor();
+	});
+	it.fuzz("No error with constructor", (data) => {
+		tests.functionNoErrorWithConstructor(data);
+	});
+
+	it.fuzz("With error", (data) => {
+		tests.functionError(data);
+	});
+
+	it.fuzz("With error with constructor", (data) => {
+		tests.functionErrorNew(data);
+	});
+
+	it.fuzz("Target string in variable name - no error", (data) => {
+		tests.functionWithArgNoError(data);
+	});
+
+	it.fuzz("With error - target string in last arg", (data) => {
+		tests.functionWithArgError(data);
+	});
+});


### PR DESCRIPTION
This allows Jazzer.js to detect calls to `eval` and `Function` and detect if user-controlled data can be passed to them.