### PR TITLE
Per fuzz-test dictionaries

### DIFF
--- a/examples/jest_integration/integration.fuzz.js
+++ b/examples/jest_integration/integration.fuzz.js
@@ -33,6 +33,16 @@ describe("My describe", () => {
 		{ dictionaries: ["Amazing"] },
 	);
 
+	const utf8Encode = new TextEncoder();
+	const binaryAmazing = utf8Encode.encode("Amazing");
+	it.fuzz(
+		"My hashed fuzz test with binary dictionary",
+		(data) => {
+			target.fuzzMeHashed(data);
+		},
+		{ dictionaries: [binaryAmazing] },
+	);
+
 	it.fuzz(
 		"My fuzz test with an explicit timeout (async)",
 		async (data) => {

--- a/examples/jest_integration/integration.fuzz.js
+++ b/examples/jest_integration/integration.fuzz.js
@@ -21,6 +21,18 @@ describe("My describe", () => {
 		target.fuzzMe(data);
 	});
 
+	it.fuzz("My hashed fuzz test without dictionary", (data) => {
+		target.fuzzMeHashed(data);
+	});
+
+	it.fuzz(
+		"My hashed fuzz test with dictionary",
+		(data) => {
+			target.fuzzMeHashed(data);
+		},
+		{ dictionaries: ["Amazing"] },
+	);
+
 	it.fuzz(
 		"My fuzz test with an explicit timeout (async)",
 		async (data) => {

--- a/examples/jest_integration/target.js
+++ b/examples/jest_integration/target.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+var crypto = require("crypto");
+
 /**
  * @param { Buffer } data
  */
@@ -22,8 +24,27 @@ const fuzzMe = function (data) {
 	if (s.length !== 7) {
 		return;
 	}
+
 	if (s.slice(0, 7) === "Awesome") {
 		throw Error("Welcome to Awesome Fuzzing!");
+	}
+};
+
+const fuzzMeHashed = function (data) {
+	const s = data.toString();
+	if (s.length !== 7) {
+		return;
+	}
+
+	const sha = crypto.createHash("sha512").update(s.slice(0, 7));
+	const result = sha.digest("hex");
+
+	// Hash of "Amazing"
+	if (
+		result ===
+		"79328e1e1272ff2890ff0c6e8181a52ce5960ae7703b00f9f094edd7dbd198210129b2bb307e8cd34d689d101e4d685f1259e42af7ce252944ca46aecca60752"
+	) {
+		throw Error("Welcome to Amazing Fuzzing!");
 	}
 };
 
@@ -50,5 +71,6 @@ const asyncFuzzMe = function (data) {
 };
 
 module.exports.fuzzMe = fuzzMe;
+module.exports.fuzzMeHashed = fuzzMeHashed;
 module.exports.callbackFuzzMe = callbackFuzzMe;
 module.exports.asyncFuzzMe = asyncFuzzMe;

--- a/packages/core/core.ts
+++ b/packages/core/core.ts
@@ -406,6 +406,7 @@ export { FuzzedDataProvider } from "./FuzzedDataProvider";
 export {
 	buildOptions,
 	defaultOptions,
+	mergeOptions,
 	Options,
 	ParameterResolverIndex,
 	setParameterResolverValue,

--- a/packages/core/dictionary.ts
+++ b/packages/core/dictionary.ts
@@ -44,13 +44,34 @@ export function addDictionary(...dictionary: string[]) {
 	getDictionary().addEntries(dictionary);
 }
 
-function convertDictionaryEntry(entry: string): string {
-	return JSON.stringify(entry);
+/* Convert Uint8Array of the form int8Array(3) [65, 109,  97] to String of the form "\"\\x41\\x6d\\x61\"" that can be
+ * decoded by libfuzzer. */
+function toEscapedHexString(byteArray: Uint8Array | Int8Array): string {
+	if (0 == byteArray.length) {
+		return '""';
+	}
+	return (
+		'"\\x' +
+		Array.from(byteArray, function (byte) {
+			return ("0" + (byte & 0xff).toString(16)).slice(-2);
+		}).join("\\x") +
+		'"'
+	);
+}
+
+function convertDictionaryEntry(
+	entry: string | Uint8Array | Int8Array,
+): string {
+	if ("string" == typeof entry) {
+		return JSON.stringify(entry);
+	} else {
+		return toEscapedHexString(entry);
+	}
 }
 
 export function useDictionaryByParams(
 	options: string[],
-	additionalDictionaryEntries: string[] = [],
+	additionalDictionaryEntries: (string | Uint8Array | Int8Array)[] = [],
 ): string[] {
 	const opts = [...options];
 

--- a/packages/core/dictionary.ts
+++ b/packages/core/dictionary.ts
@@ -44,9 +44,21 @@ export function addDictionary(...dictionary: string[]) {
 	getDictionary().addEntries(dictionary);
 }
 
-export function useDictionaryByParams(options: string[]): string[] {
+function convertDictionaryEntry(entry: string): string {
+	return JSON.stringify(entry);
+}
+
+export function useDictionaryByParams(
+	options: string[],
+	additionalDictionaryEntries: string[] = [],
+): string[] {
 	const opts = [...options];
-	const dictionary = getDictionary().entries;
+
+	const additionalDictionary = additionalDictionaryEntries.map(
+		convertDictionaryEntry,
+	);
+
+	const dictionary = getDictionary().entries.concat(additionalDictionary);
 
 	// This diverges from the libFuzzer behavior, which allows only one dictionary (the last one).
 	// We merge all dictionaries into one and pass that to libfuzzer.

--- a/packages/core/options.ts
+++ b/packages/core/options.ts
@@ -59,7 +59,7 @@ export interface Options {
 	// Disable bug detectors by name.
 	disableBugDetectors: string[];
 	// Fuzzing dictionaries
-	dictionaries: string[];
+	dictionaries: (string | Uint8Array | Int8Array)[];
 	// Fuzzing mode.
 	mode: "fuzzing" | "regression";
 	// Verbose logging.

--- a/packages/core/options.ts
+++ b/packages/core/options.ts
@@ -193,7 +193,7 @@ export function buildOptions(): Options {
 	return options;
 }
 
-function mergeOptions(
+export function mergeOptions(
 	input: unknown,
 	defaults: Options,
 	transformKey: (key: string) => string,

--- a/packages/core/options.ts
+++ b/packages/core/options.ts
@@ -58,6 +58,8 @@ export interface Options {
 	coverageReporters: string[];
 	// Disable bug detectors by name.
 	disableBugDetectors: string[];
+	// Fuzzing dictionaries
+	dictionaries: string[];
 	// Fuzzing mode.
 	mode: "fuzzing" | "regression";
 	// Verbose logging.
@@ -80,6 +82,7 @@ export const defaultOptions: Options = Object.freeze({
 	coverageDirectory: "coverage",
 	coverageReporters: ["json", "text", "lcov", "clover"], // default Jest reporters
 	disableBugDetectors: [],
+	dictionaries: [],
 	mode: "fuzzing",
 	verbose: false,
 });
@@ -248,7 +251,7 @@ export function buildFuzzerOption(options: Options) {
 	let params: string[] = [];
 	params = optionDependentParams(options, params);
 	params = forkedExecutionParams(params);
-	params = useDictionaryByParams(params);
+	params = useDictionaryByParams(params, options.dictionaries);
 
 	// libFuzzer has to ignore SIGINT and SIGTERM, as it interferes
 	// with the Node.js signal handling.

--- a/packages/jest-runner/fuzz.ts
+++ b/packages/jest-runner/fuzz.ts
@@ -103,6 +103,12 @@ export function fuzz(
 			localConfig = mergeOptions(timeoutOrOptions, localConfig, (key) => {
 				return key;
 			});
+
+			// Overwrite localConfig.dictionaries with timeoutOrOptions.dictionaries if set. This hack is in place since
+			// mergeOptions will coerce dictionary entries into objects, but we don't want this to happen.
+			if (timeoutOrOptions.dictionaries != undefined) {
+				localConfig.dictionaries = timeoutOrOptions.dictionaries;
+			}
 		}
 
 		// Timeout priority is:
@@ -139,7 +145,7 @@ export function fuzz(
 		}
 
 		const corpus = new Corpus(testFile, testStatePath, localConfig.coverage);
-		
+
 		const wrappedFn = asFindingAwareFuzzFn(fn, localConfig.mode === "fuzzing");
 
 		if (localConfig.mode === "regression") {

--- a/packages/jest-runner/fuzz.ts
+++ b/packages/jest-runner/fuzz.ts
@@ -88,7 +88,9 @@ export function fuzz(
 		fn,
 		timeoutOrOptions:
 			| number
-			| Partial<Pick<Options, "sync" | "fuzzerOptions" | "timeout">>
+			| Partial<
+					Pick<Options, "sync" | "fuzzerOptions" | "timeout" | "dictionaries">
+			  >
 			| undefined,
 	) => {
 		// Deep clone the fuzzing config, so that each test can modify it without

--- a/tests/jest_integration/integration.test.js
+++ b/tests/jest_integration/integration.test.js
@@ -208,6 +208,16 @@ describe("Jest integration", () => {
 				);
 			});
 		});
+		describe("dictionary support", () => {
+			it("with dictionary", async () => {
+				const fuzzTest = fuzzTestBuilder
+					.jestTestName("execute sync hashed fuzz test with dictionary")
+					.build();
+				expect(() => {
+					fuzzTest.execute();
+				}).toThrow(JestRegressionExitCode);
+			});
+		});
 	});
 
 	describe("Regression mode", () => {

--- a/tests/jest_integration/integration.test.js
+++ b/tests/jest_integration/integration.test.js
@@ -107,6 +107,17 @@ describe("Jest integration", () => {
 		});
 
 		describe("timeout", () => {
+			it("execute sync timeout test", async () => {
+				const fuzzTest = fuzzTestBuilder
+					.jestTestName("execute sync timeout test plain")
+					.build();
+				expect(() => {
+					fuzzTest.execute();
+				}).toThrow(TimeoutExitCode);
+				assertTimeoutMessageLogged(fuzzTest, 5);
+				await expectCrashFileIn("execute_sync_timeout_test_plain");
+			});
+
 			it("execute async timeout test", async () => {
 				const fuzzTest = fuzzTestBuilder
 					.jestTestName("execute async timeout test plain")

--- a/tests/jest_integration/jest_project/integration.fuzz.js
+++ b/tests/jest_integration/jest_project/integration.fuzz.js
@@ -37,6 +37,14 @@ describe("Jest Integration", () => {
 		target.fuzzMe(data);
 	});
 
+	it.fuzz(
+		"execute sync hashed fuzz test with dictionary",
+		(data) => {
+			target.fuzzMeHashed(data);
+		},
+		{ dictionaries: ["Amazing"] },
+	);
+
 	it.fuzz("execute async test", async (data) => {
 		await target.asyncFuzzMe(data);
 	});

--- a/tests/jest_integration/jest_project/integration.fuzz.js
+++ b/tests/jest_integration/jest_project/integration.fuzz.js
@@ -53,6 +53,10 @@ describe("Jest Integration", () => {
 		await target.asyncTimeout(data);
 	});
 
+	it.fuzz("execute sync timeout test plain", (data) => {
+		target.syncTimeout(data);
+	});
+
 	it.fuzz(
 		"execute async timeout test with method timeout",
 		async (data) => {

--- a/tests/jest_integration/jest_project/target.js
+++ b/tests/jest_integration/jest_project/target.js
@@ -14,12 +14,34 @@
  * limitations under the License.
  */
 
+const crypto = require("crypto");
+
 const fuzzMe = (data) => {
 	if (data.toString() === "Awe") {
 		throw Error("Welcome to Awesome Fuzzing!");
 	}
 };
 module.exports.fuzzMe = fuzzMe;
+
+const fuzzMeHashed = function (data) {
+	const s = data.toString();
+	if (s.length !== 7) {
+		return;
+	}
+
+	const sha = crypto.createHash("sha512").update(s.slice(0, 7));
+	const result = sha.digest("hex");
+
+	// Hash of "Amazing"
+	if (
+		result ===
+		"79328e1e1272ff2890ff0c6e8181a52ce5960ae7703b00f9f094edd7dbd198210129b2bb307e8cd34d689d101e4d685f1259e42af7ce252944ca46aecca60752"
+	) {
+		throw Error("Welcome to Amazing Fuzzing!");
+	}
+};
+
+module.exports.fuzzMeHashed = fuzzMeHashed;
 
 module.exports.asyncFuzzMe = (data) =>
 	new Promise((resolve, reject) => {

--- a/tests/jest_integration/jest_project/target.js
+++ b/tests/jest_integration/jest_project/target.js
@@ -52,6 +52,13 @@ module.exports.asyncTimeout = (data) =>
 		// Never resolve this promise to provoke a timeout.
 	});
 
+module.exports.syncTimeout = (data) => {
+	// eslint-disable-next-line no-constant-condition
+	while (true) {
+		/* empty */
+	}
+};
+
 // noinspection JSUnusedLocalSymbols
 module.exports.callbackTimeout = (data, done) => {
 	// Never call done to provoke a timeout.


### PR DESCRIPTION
This adds the capability to add single dictionary entries per fuzz tests.

One part of the last commit ([Per fuzz-test dictionaries: Allow for byte arrays as dictionary entries](https://github.com/CodeIntelligenceTesting/jazzer.js/pull/656/commits/de396bab4c24db9930b7d7e5b49c82f343031971)) might be considered a bit hacky. Cleaning that up might require to think about how [mergeOptions](https://github.com/CodeIntelligenceTesting/jazzer.js/blob/7dd049cd4bcd2939d5313911ce585c396d40ba78/packages/core/options.ts#L196) works, since that currently converts our Uint8Array into an object.

First commit ([Add test for sync timeout](https://github.com/CodeIntelligenceTesting/jazzer.js/pull/656/commits/94b4f15a792fafba39c25dcc3b573f8e142d4ad6)) is an unrelated mini-fix.