### PR TITLE
test(e2e): test CLI in addition to jest integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     versioning-strategy: increase
+    ignore:
+      - dependency-name: "yargs"
+        versions:
+          - ">=18.0.0"
     groups:
       minor-dependencies:
         update-types:

--- a/.github/workflows/run-all-tests-pr.yaml
+++ b/.github/workflows/run-all-tests-pr.yaml
@@ -107,55 +107,56 @@ jobs:
 
       # Run with different node.js versions
       # all in one job to avoid rebuilding
+      # each runtime executes consolidated runtime checks
       # Node 14 only has binaries for x64 runners
       - name: "node 14"
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'
         uses: actions/setup-node@v6
         with:
           node-version: 14
-      - name: run tests (node 14)
+      - name: run runtime checks (node 14)
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'
-        run: cd end-to-end && npx jest
+        run: cd end-to-end && npm run test:runtime
         shell: bash
 
       - name: "node 16"
         uses: actions/setup-node@v6
         with:
           node-version: 16
-      - name: run tests (node 16)
-        run: cd end-to-end && npx jest
+      - name: run runtime checks (node 16)
+        run: cd end-to-end && npm run test:runtime
         shell: bash
 
       - name: "node 18"
         uses: actions/setup-node@v6
         with:
           node-version: 18
-      - name: run tests (node 18)
-        run: cd end-to-end && npx jest
+      - name: run runtime checks (node 18)
+        run: cd end-to-end && npm run test:runtime
         shell: bash
 
       - name: "node 20"
         uses: actions/setup-node@v6
         with:
           node-version: 20
-      - name: run tests (node 20)
-        run: cd end-to-end && npx jest
+      - name: run runtime checks (node 20)
+        run: cd end-to-end && npm run test:runtime
         shell: bash
 
       - name: "node 22"
         uses: actions/setup-node@v6
         with:
           node-version: 22
-      - name: run tests (node 22)
-        run: cd end-to-end && npx jest
+      - name: run runtime checks (node 22)
+        run: cd end-to-end && npm run test:runtime
         shell: bash
 
       - name: "node 24"
         uses: actions/setup-node@v6
         with:
           node-version: 24
-      - name: run tests (node 24)
-        run: cd end-to-end && npx jest
+      - name: run runtime checks (node 24)
+        run: cd end-to-end && npm run test:runtime
         shell: bash
   auto-merge:
     needs:

--- a/end-to-end/cli-smoke.cjs
+++ b/end-to-end/cli-smoke.cjs
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports.fuzz = function fuzz() {};

--- a/end-to-end/package.json
+++ b/end-to-end/package.json
@@ -4,6 +4,8 @@
 	"scripts": {
 		"build": "tsc",
 		"dryRun": "jest",
+		"fuzz:cli": "jazzer cli-smoke.cjs --sync -- -runs=1 -seed=123456789 -max_len=32",
+		"test:runtime": "npm run dryRun && npm run fuzz:cli",
 		"fuzz": "JAZZER_FUZZ=1 jest --coverage",
 		"coverage": "jest --coverage"
 	},


### PR DESCRIPTION
- previously, only Jest test was run in our e2e tests
- dependabot upgraded yargs to 18 (ESM-first) and nothing failed, even though node version14 and 16 should fail with this change