### PR TITLE
chore(ts): add root project references for editor tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	},
 	"scripts": {
 		"prepare": "husky || true",
-		"build": "tsc -b tsconfig.build.json",
+		"build": "tsc -b tsconfig.json",
 		"clean": "rimraf -g **/node_modules **/tests/**/package-lock.json **/examples/**/package-lock.json **/dist **/coverage packages/fuzzer/build packages/fuzzer/prebuilds",
 		"compile:watch": "tsc -b tsconfig.build.json --incremental --pretty --watch",
 		"test": "run-script-os",

--- a/packages/bug-detectors/tsconfig.json
+++ b/packages/bug-detectors/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": ".",
 		"outDir": "dist"

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": ".",
 		"outDir": "dist"

--- a/packages/fuzzer/tsconfig.json
+++ b/packages/fuzzer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": ".",
 		"outDir": "dist"

--- a/packages/hooking/tsconfig.json
+++ b/packages/hooking/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": ".",
 		"outDir": "dist"

--- a/packages/instrumentor/tsconfig.json
+++ b/packages/instrumentor/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": ".",
 		"outDir": "dist"

--- a/packages/jest-runner/tsconfig.json
+++ b/packages/jest-runner/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": ".",
 		"outDir": "dist"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "NodeNext",
+		"baseUrl": "./",
+		"allowJs": true,
+		"checkJs": true,
+		"outDir": "./dist",
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"declaration": true,
+		"declarationMap": true,
+		"composite": true,
+		"alwaysStrict": true,
+		"sourceMap": true
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,12 @@
 {
-	"compilerOptions": {
-		"target": "ES2020",
-		"module": "NodeNext",
-		"baseUrl": "./",
-		"allowJs": true,
-		"checkJs": true,
-		"outDir": "./dist",
-		"esModuleInterop": true,
-		"forceConsistentCasingInFileNames": true,
-		"strict": true,
-		"skipLibCheck": true,
-		"declaration": true,
-		"composite": true,
-		"alwaysStrict": true,
-		"sourceMap": true
-	}
+	"extends": "./tsconfig.base.json",
+	"files": [],
+	"references": [
+		{ "path": "packages/bug-detectors" },
+		{ "path": "packages/core" },
+		{ "path": "packages/fuzzer" },
+		{ "path": "packages/hooking" },
+		{ "path": "packages/instrumentor" },
+		{ "path": "packages/jest-runner" }
+	]
 }


### PR DESCRIPTION
Split shared compiler options into tsconfig.base.json so the root tsconfig.json can describe the workspace project graph.

This lets TypeScript language servers resolve references across package boundaries while keeping package builds on the same compiler settings.