### PR TITLE
fix(bug-detectors): handle connect(port, host) in ssrf tcp hook

### DIFF
--- a/packages/bug-detectors/internal/ssrf.test.ts
+++ b/packages/bug-detectors/internal/ssrf.test.ts
@@ -167,6 +167,13 @@ describe("SSRF", () => {
 			expect(() =>
 				hookTCPSocket(undefined, [80, "localhost", "callback"], 0),
 			).not.toThrow();
+			// connect(port, host) without a listener
+			expect(() => hookTCPSocket(undefined, [8080, "local"], 0)).toThrow(
+				"Server Side Request Forgery",
+			);
+			expect(() =>
+				hookTCPSocket(undefined, [80, "localhost"], 0),
+			).not.toThrow();
 		});
 
 		test("Call TCP socket hook with ports as strings", () => {
@@ -193,6 +200,13 @@ describe("SSRF", () => {
 			// allowed connection with explicit port and host
 			expect(() =>
 				hookTCPSocket(undefined, ["80", "localhost", "callback"], 0),
+			).not.toThrow();
+			// connect(port, host) without a listener
+			expect(() => hookTCPSocket(undefined, ["81", "local"], 0)).toThrow(
+				"Server Side Request Forgery",
+			);
+			expect(() =>
+				hookTCPSocket(undefined, ["80", "localhost"], 0),
 			).not.toThrow();
 		});
 	});

--- a/packages/bug-detectors/internal/ssrf.ts
+++ b/packages/bug-detectors/internal/ssrf.ts
@@ -185,11 +185,14 @@ export function hookTCPSocket(_thisPtr: unknown, args: unknown[], _id: number) {
 			detectSSRF(port, host, "Attempted connection via TCP");
 		}
 	} else if (args.length === 2) {
-		// connect(options: SocketConnectOpts, connectionListener?: () => void): this;
 		const firstArgument = args[0];
 		if (typeof firstArgument === "object" && firstArgument !== null) {
+			// connect(options: SocketConnectOpts, connectionListener?: () => void): this;
 			const options = firstArgument as TcpSocketConnectOpts;
 			detectSSRF(options.port, options.host, "Attempted connection via TCP");
+		} else if (typeof args[1] === "string") {
+			// connect(port: number, host: string): this;
+			detectSSRF(firstArgument, args[1], "Attempted connection via TCP");
 		}
 	} else if (args.length === 3) {
 		// connect(port: number, host: string, connectionListener?: () => void): this;


### PR DESCRIPTION
hookTCPSocket maps argument count to the documented Socket.connect overloads, but the two-argument branch only handles connect(options, listener). The connect(port, host) form with no listener falls through unchecked, so the SSRF allowlist is never consulted and a target calling socket.connect(8080, "evil.com") evades detection. The new branch routes the (port, host) case through detectSSRF like the three-argument path. Tests cover numeric and string ports.